### PR TITLE
Replace usage of depercated PVStructure::get*Field methods

### DIFF
--- a/pvtoolsSrc/eget.cpp
+++ b/pvtoolsSrc/eget.cpp
@@ -335,7 +335,7 @@ void formatNTTable(std::ostream& o, PVStructurePtr const & pvStruct)
         return;
     }
 
-    PVStructurePtr value = pvStruct->getStructureField("value");
+    PVStructurePtr value = pvStruct->getSubField<PVStructure>("value");
     if (value.get() == 0)
     {
         std::cerr << "no 'value' structure in NTTable" << std::endl;
@@ -613,7 +613,7 @@ void formatNTNameValue(std::ostream& o, PVStructurePtr const & pvStruct)
 
 void formatNTURI(std::ostream& o, PVStructurePtr const & pvStruct)
 {
-    PVStringPtr scheme = dynamic_pointer_cast<PVString>(pvStruct->getStringField("scheme"));
+    PVStringPtr scheme = dynamic_pointer_cast<PVString>(pvStruct->getSubField<PVString>("scheme"));
     if (scheme.get() == 0)
     {
         std::cerr << "no string 'scheme' field in NTURI" << std::endl;
@@ -621,7 +621,7 @@ void formatNTURI(std::ostream& o, PVStructurePtr const & pvStruct)
 
     PVStringPtr authority = dynamic_pointer_cast<PVString>(pvStruct->getSubField("authority"));
 
-    PVStringPtr path = dynamic_pointer_cast<PVString>(pvStruct->getStringField("path"));
+    PVStringPtr path = dynamic_pointer_cast<PVString>(pvStruct->getSubField<PVString>("path"));
     if (path.get() == 0)
     {
         std::cerr << "no string 'path' field in NTURI" << std::endl;
@@ -2065,15 +2065,15 @@ int main (int argc, char *argv[])
                     getPVDataCreate()->createPVStructure(uriStructure)
                     );
 
-        request->getStringField("scheme")->put("pva");
-        if (!authority.empty()) request->getStringField("authority")->put(authority);
-        request->getStringField("path")->put(service);
-        PVStructure::shared_pointer query = request->getStructureField("query");
+        request->getSubField<PVString>("scheme")->put("pva");
+        if (!authority.empty()) request->getSubField<PVString>("authority")->put(authority);
+        request->getSubField<PVString>("path")->put(service);
+        PVStructure::shared_pointer query = request->getSubField<PVStructure>("query");
         for (vector< pair<string, string> >::iterator iter = parameters.begin();
              iter != parameters.end();
              iter++)
         {
-            query->getStringField(iter->first)->put(iter->second);
+            query->getSubField<PVString>(iter->first)->put(iter->second);
         }
 
 

--- a/src/ca/caChannel.cpp
+++ b/src/ca/caChannel.cpp
@@ -644,10 +644,10 @@ void copy_DBR_STS(const void * dbr, unsigned count, PVStructure::shared_pointer 
 {
     const T* data = static_cast<const T*>(dbr);
 
-    PVStructure::shared_pointer alarm = pvStructure->getStructureField("alarm");
-    alarm->getIntField("status")->put(dbrStatus2alarmStatus[data->status]);
-    alarm->getIntField("severity")->put(data->severity);
-    alarm->getStringField("message")->put(dbrStatus2alarmMessage[data->status]);
+    PVStructure::shared_pointer alarm = pvStructure->getSubField<PVStructure>("alarm");
+    alarm->getSubField<PVInt>("status")->put(dbrStatus2alarmStatus[data->status]);
+    alarm->getSubField<PVInt>("severity")->put(data->severity);
+    alarm->getSubField<PVString>("message")->put(dbrStatus2alarmMessage[data->status]);
 
     copy_DBR<pT, sT, sF, aF>(&data->value, count, pvStructure);
 }
@@ -658,11 +658,11 @@ void copy_DBR_TIME(const void * dbr, unsigned count, PVStructure::shared_pointer
 {
     const T* data = static_cast<const T*>(dbr);
 
-    PVStructure::shared_pointer ts = pvStructure->getStructureField("timeStamp");
+    PVStructure::shared_pointer ts = pvStructure->getSubField<PVStructure>("timeStamp");
     epics::pvData::int64 spe = data->stamp.secPastEpoch;
     spe += 7305*86400;
-    ts->getLongField("secondsPastEpoch")->put(spe);
-    ts->getIntField("nanoseconds")->put(data->stamp.nsec);
+    ts->getSubField<PVLong>("secondsPastEpoch")->put(spe);
+    ts->getSubField<PVInt>("nanoseconds")->put(data->stamp.nsec);
 
     copy_DBR_STS<T, pT, sT, sF, aF>(dbr, count, pvStructure);
 }
@@ -671,13 +671,13 @@ void copy_DBR_TIME(const void * dbr, unsigned count, PVStructure::shared_pointer
 template <typename T>
 void copy_format(const void * /*dbr*/, PVStructure::shared_pointer const & pvDisplayStructure)
 {
-    pvDisplayStructure->getStringField("format")->put("%d");
+    pvDisplayStructure->getSubField<PVString>("format")->put("%d");
 }
 
 template <>
 void copy_format<dbr_time_string>(const void * /*dbr*/, PVStructure::shared_pointer const & pvDisplayStructure)
 {
-    pvDisplayStructure->getStringField("format")->put("%s");
+    pvDisplayStructure->getSubField<PVString>("format")->put("%s");
 }
 
 #define COPY_FORMAT_FOR(T) \
@@ -690,11 +690,11 @@ void copy_format<T>(const void * dbr, PVStructure::shared_pointer const & pvDisp
     { \
         char fmt[16]; \
         sprintf(fmt, "%%.%df", data->precision); \
-        pvDisplayStructure->getStringField("format")->put(std::string(fmt)); \
+        pvDisplayStructure->getSubField<PVString>("format")->put(std::string(fmt)); \
     } \
     else \
     { \
-        pvDisplayStructure->getStringField("format")->put("%f"); \
+        pvDisplayStructure->getSubField<PVString>("format")->put("%f"); \
     } \
 }
 
@@ -711,23 +711,23 @@ void copy_DBR_GR(const void * dbr, unsigned count, PVStructure::shared_pointer c
 {
     const T* data = static_cast<const T*>(dbr);
 
-    PVStructure::shared_pointer alarm = pvStructure->getStructureField("alarm");
-    alarm->getIntField("status")->put(0);
-    alarm->getIntField("severity")->put(data->severity);
-    alarm->getStringField("message")->put(dbrStatus2alarmMessage[data->status]);
+    PVStructure::shared_pointer alarm = pvStructure->getSubField<PVStructure>("alarm");
+    alarm->getSubField<PVInt>("status")->put(0);
+    alarm->getSubField<PVInt>("severity")->put(data->severity);
+    alarm->getSubField<PVString>("message")->put(dbrStatus2alarmMessage[data->status]);
 
-    PVStructure::shared_pointer disp = pvStructure->getStructureField("display");
-    disp->getStringField("units")->put(std::string(data->units));
-    disp->getDoubleField("limitHigh")->put(data->upper_disp_limit);
-    disp->getDoubleField("limitLow")->put(data->lower_disp_limit);
+    PVStructure::shared_pointer disp = pvStructure->getSubField<PVStructure>("display");
+    disp->getSubField<PVString>("units")->put(std::string(data->units));
+    disp->getSubField<PVDouble>("limitHigh")->put(data->upper_disp_limit);
+    disp->getSubField<PVDouble>("limitLow")->put(data->lower_disp_limit);
 
     copy_format<T>(dbr, disp);
 
-    PVStructure::shared_pointer va = pvStructure->getStructureField("valueAlarm");
-    va->getDoubleField("highAlarmLimit")->put(data->upper_alarm_limit);
-    va->getDoubleField("highWarningLimit")->put(data->upper_warning_limit);
-    va->getDoubleField("lowWarningLimit")->put(data->lower_warning_limit);
-    va->getDoubleField("lowAlarmLimit")->put(data->lower_alarm_limit);
+    PVStructure::shared_pointer va = pvStructure->getSubField<PVStructure>("valueAlarm");
+    va->getSubField<PVDouble>("highAlarmLimit")->put(data->upper_alarm_limit);
+    va->getSubField<PVDouble>("highWarningLimit")->put(data->upper_warning_limit);
+    va->getSubField<PVDouble>("lowWarningLimit")->put(data->lower_warning_limit);
+    va->getSubField<PVDouble>("lowAlarmLimit")->put(data->lower_alarm_limit);
 
     copy_DBR<pT, sT, sF, aF>(&data->value, count, pvStructure);
 }
@@ -749,27 +749,27 @@ void copy_DBR_CTRL(const void * dbr, unsigned count, PVStructure::shared_pointer
 {
     const T* data = static_cast<const T*>(dbr);
 
-    PVStructure::shared_pointer alarm = pvStructure->getStructureField("alarm");
-    alarm->getIntField("status")->put(0);
-    alarm->getIntField("severity")->put(data->severity);
-    alarm->getStringField("message")->put(dbrStatus2alarmMessage[data->status]);
+    PVStructure::shared_pointer alarm = pvStructure->getSubField<PVStructure>("alarm");
+    alarm->getSubField<PVInt>("status")->put(0);
+    alarm->getSubField<PVInt>("severity")->put(data->severity);
+    alarm->getSubField<PVString>("message")->put(dbrStatus2alarmMessage[data->status]);
 
-    PVStructure::shared_pointer disp = pvStructure->getStructureField("display");
-    disp->getStringField("units")->put(std::string(data->units));
-    disp->getDoubleField("limitHigh")->put(data->upper_disp_limit);
-    disp->getDoubleField("limitLow")->put(data->lower_disp_limit);
+    PVStructure::shared_pointer disp = pvStructure->getSubField<PVStructure>("display");
+    disp->getSubField<PVString>("units")->put(std::string(data->units));
+    disp->getSubField<PVDouble>("limitHigh")->put(data->upper_disp_limit);
+    disp->getSubField<PVDouble>("limitLow")->put(data->lower_disp_limit);
 
     copy_format<T>(dbr, disp);
 
-    PVStructure::shared_pointer va = pvStructure->getStructureField("valueAlarm");
+    PVStructure::shared_pointer va = pvStructure->getSubField<PVStructure>("valueAlarm");
     std::tr1::static_pointer_cast<sF>(va->getSubField("highAlarmLimit"))->put(data->upper_alarm_limit);
     std::tr1::static_pointer_cast<sF>(va->getSubField("highWarningLimit"))->put(data->upper_warning_limit);
     std::tr1::static_pointer_cast<sF>(va->getSubField("lowWarningLimit"))->put(data->lower_warning_limit);
     std::tr1::static_pointer_cast<sF>(va->getSubField("lowAlarmLimit"))->put(data->lower_alarm_limit);
 
-    PVStructure::shared_pointer ctrl = pvStructure->getStructureField("control");
-    ctrl->getDoubleField("limitHigh")->put(data->upper_ctrl_limit);
-    ctrl->getDoubleField("limitLow")->put(data->lower_ctrl_limit);
+    PVStructure::shared_pointer ctrl = pvStructure->getSubField<PVStructure>("control");
+    ctrl->getSubField<PVDouble>("limitHigh")->put(data->upper_ctrl_limit);
+    ctrl->getSubField<PVDouble>("limitLow")->put(data->lower_ctrl_limit);
 
     copy_DBR<pT, sT, sF, aF>(&data->value, count, pvStructure);
 }

--- a/src/remoteClient/clientContextImpl.cpp
+++ b/src/remoteClient/clientContextImpl.cpp
@@ -2400,13 +2400,11 @@ namespace epics {
                 }
                 
                int queueSize = 2;
-               PVFieldPtr pvField = m_pvRequest->getSubField("record._options");
-               if (pvField.get()) {
-                   PVStructurePtr pvOptions = static_pointer_cast<PVStructure>(pvField);
-                   pvField = pvOptions->getSubField("queueSize");
-                   if (pvField.get()) {
-                       PVStringPtr pvString = pvOptions->getStringField("queueSize");
-                       if(pvString) {
+               {
+                   PVStructurePtr pvOptions = m_pvRequest->getSubField<PVStructure>("record._options");
+                   if(pvOptions.get()) {
+                       PVStringPtr pvString = pvOptions->getSubField<PVString>("queueSize");
+                       if(pvString.get()) {
                            int32 size;
                            std::stringstream ss;
                            ss << pvString->get();

--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -516,7 +516,7 @@ public:
         // NTURI support
         PVStructure::shared_pointer args(
                     (starts_with(arguments->getStructure()->getID(), "epics:nt/NTURI:1.")) ?
-                        arguments->getStructureField("query") :
+                        arguments->getSubField<PVStructure>("query") :
                         arguments
                         );
 

--- a/testApp/remote/channelAccessIFTest.cpp
+++ b/testApp/remote/channelAccessIFTest.cpp
@@ -549,11 +549,11 @@ void ChannelAccessIFTest::test_channelGetIntProcessInternal(Channel::shared_poin
     return;
   }
 
-  std::tr1::shared_ptr<PVInt> value = channelGetReq->getPVStructure()->getIntField("value");
+  std::tr1::shared_ptr<PVInt> value = channelGetReq->getPVStructure()->getSubField<PVInt>("value");
 
   PVTimeStamp pvTimeStamp;
 
-  testOk(pvTimeStamp.attach(channelGetReq->getPVStructure()->getStructureField("timeStamp")),
+  testOk(pvTimeStamp.attach(channelGetReq->getPVStructure()->getSubField<PVStructure>("timeStamp")),
       "%s: attaching a timestamp", testMethodName.c_str());
 
   TimeStamp timeStamp;
@@ -679,7 +679,7 @@ void ChannelAccessIFTest::test_channelPutNoProcess() {
     return;
   } 
 
-  std::tr1::shared_ptr<PVDouble> value = channelPutReq->getPVStructure()->getDoubleField("value");
+  std::tr1::shared_ptr<PVDouble> value = channelPutReq->getPVStructure()->getSubField<PVDouble>("value");
   if (!value.get()) {
     testFail("%s: getting double value field failed ", CURRENT_FUNCTION);
     return;
@@ -818,7 +818,7 @@ void ChannelAccessIFTest::test_channelPutIntProcessInternal(Channel::shared_poin
     return;
   } 
 
-  std::tr1::shared_ptr<PVInt> value = channelPutReq->getPVStructure()->getIntField("value");
+  std::tr1::shared_ptr<PVInt> value = channelPutReq->getPVStructure()->getSubField<PVInt>("value");
   if (!value.get()) {
     testFail("%s: getting int value field failed ", testMethodName.c_str());
     return;
@@ -1213,7 +1213,7 @@ void ChannelAccessIFTest::test_channelPutGetNoProcess_putGet() {
   } 
 
 
-  std::tr1::shared_ptr<PVDouble> putValue = channelPutGetReq->getPVPutStructure()->getDoubleField("value");
+  std::tr1::shared_ptr<PVDouble> putValue = channelPutGetReq->getPVPutStructure()->getSubField<PVDouble>("value");
   if (!putValue.get()) {
     testFail("%s: getting put double value field failed ", CURRENT_FUNCTION);
     return;
@@ -1222,7 +1222,7 @@ void ChannelAccessIFTest::test_channelPutGetNoProcess_putGet() {
   double initVal = 321.0;
   putValue->put(initVal);
 
-  std::tr1::shared_ptr<PVDouble> getValuePtr = channelPutGetReq->getPVGetStructure()->getDoubleField("value");
+  std::tr1::shared_ptr<PVDouble> getValuePtr = channelPutGetReq->getPVGetStructure()->getSubField<PVDouble>("value");
   if (!getValuePtr.get()) {
     testFail("%s: getting get double value field failed ", CURRENT_FUNCTION);
     return;
@@ -1292,7 +1292,7 @@ void ChannelAccessIFTest::test_channelPutGetNoProcess_getPut() {
   } 
 
 
-  std::tr1::shared_ptr<PVDouble> putValue = channelPutGetReq->getPVPutStructure()->getDoubleField("value");
+  std::tr1::shared_ptr<PVDouble> putValue = channelPutGetReq->getPVPutStructure()->getSubField<PVDouble>("value");
   if (!putValue.get()) {
     testFail("%s: getting put double value field failed ", CURRENT_FUNCTION);
     return;
@@ -1301,7 +1301,7 @@ void ChannelAccessIFTest::test_channelPutGetNoProcess_getPut() {
   double initVal = 321.0;
   putValue->put(initVal);
 
-  std::tr1::shared_ptr<PVDouble> getValuePtr = channelPutGetReq->getPVGetStructure()->getDoubleField("value");
+  std::tr1::shared_ptr<PVDouble> getValuePtr = channelPutGetReq->getPVGetStructure()->getSubField<PVDouble>("value");
   if (!getValuePtr.get()) {
     testFail("%s: getting get double value field failed ", CURRENT_FUNCTION);
     return;
@@ -1369,7 +1369,7 @@ void ChannelAccessIFTest::test_channelPutGetNoProcess_getGet() {
   } 
 
 
-  std::tr1::shared_ptr<PVDouble> putValue = channelPutGetReq->getPVPutStructure()->getDoubleField("value");
+  std::tr1::shared_ptr<PVDouble> putValue = channelPutGetReq->getPVPutStructure()->getSubField<PVDouble>("value");
   if (!putValue.get()) {
     testFail("%s: getting put double value field failed ", CURRENT_FUNCTION);
     return;
@@ -1378,7 +1378,7 @@ void ChannelAccessIFTest::test_channelPutGetNoProcess_getGet() {
   double initVal = 432.0;
   putValue->put(initVal);
 
-  std::tr1::shared_ptr<PVDouble> getValuePtr = channelPutGetReq->getPVGetStructure()->getDoubleField("value");
+  std::tr1::shared_ptr<PVDouble> getValuePtr = channelPutGetReq->getPVGetStructure()->getSubField<PVDouble>("value");
   if (!getValuePtr.get()) {
     testFail("%s: getting get double value field failed ", CURRENT_FUNCTION);
     return;
@@ -1505,7 +1505,7 @@ void ChannelAccessIFTest::test_channelPutGetIntProcess() {
   } 
 
 
-  std::tr1::shared_ptr<PVInt> putValue = channelPutGetReq->getPVPutStructure()->getIntField("value");
+  std::tr1::shared_ptr<PVInt> putValue = channelPutGetReq->getPVPutStructure()->getSubField<PVInt>("value");
   if (!putValue.get()) {
     testFail("%s: getting put int value field failed ", CURRENT_FUNCTION);
     return;
@@ -1514,7 +1514,7 @@ void ChannelAccessIFTest::test_channelPutGetIntProcess() {
   int initVal = 3;
   putValue->put(initVal);
 
-  std::tr1::shared_ptr<PVInt> getValuePtr = channelPutGetReq->getPVGetStructure()->getIntField("value");
+  std::tr1::shared_ptr<PVInt> getValuePtr = channelPutGetReq->getPVGetStructure()->getSubField<PVInt>("value");
   if (!getValuePtr.get()) {
     testFail("%s: getting get int value field failed ", CURRENT_FUNCTION);
     return;
@@ -1522,7 +1522,7 @@ void ChannelAccessIFTest::test_channelPutGetIntProcess() {
 
   PVTimeStamp pvTimeStamp;
 
-  testOk(pvTimeStamp.attach(channelPutGetReq->getPVGetStructure()->getStructureField("timeStamp")),
+  testOk(pvTimeStamp.attach(channelPutGetReq->getPVGetStructure()->getSubField<PVStructure>("timeStamp")),
       "%s: attaching a timestamp", CURRENT_FUNCTION);
 
   TimeStamp timeStamp;
@@ -1597,7 +1597,7 @@ void ChannelAccessIFTest::test_channelRPC() {
       createSumArgumentStructure(1,2),false, getTimeoutSec());
   if (succStatus) {
     testOk(true, "%s: calling sum rpc service successfull", CURRENT_FUNCTION);
-    testOk(channelRPCReq->getLastResponse()->getIntField("c")->get() == 3, 
+    testOk(channelRPCReq->getLastResponse()->getSubField<PVInt>("c")->get() == 3, 
         "%s: rpc service returned correct sum", CURRENT_FUNCTION);
   }
   else {
@@ -2329,8 +2329,8 @@ PVStructure::shared_pointer ChannelAccessIFTest::createSumArgumentStructure(int 
       getPVDataCreate()->createPVStructure(
         getFieldCreate()->createStructure(fieldNames, fields)));
 
-  pvArguments->getIntField("a")->put(a);
-  pvArguments->getIntField("b")->put(b);
+  pvArguments->getSubField<PVInt>("a")->put(a);
+  pvArguments->getSubField<PVInt>("b")->put(b);
 
   return pvArguments;
 
@@ -2344,7 +2344,7 @@ PVStructure::shared_pointer ChannelAccessIFTest::createArrayPvRequest() {
   PVStructure::shared_pointer pvRequest(getPVDataCreate()->createPVStructure(
         getFieldCreate()->createStructure(fieldNames, fields)));
 
-  PVString::shared_pointer pvFieldName = pvRequest->getStringField("field");
+  PVString::shared_pointer pvFieldName = pvRequest->getSubField<PVString>("field");
   pvFieldName->put("value");
   return pvRequest;
 }

--- a/testApp/remote/rpcServiceAsyncExample.cpp
+++ b/testApp/remote/rpcServiceAsyncExample.cpp
@@ -29,7 +29,7 @@ class SumServiceImpl :
         // NTURI support
         PVStructure::shared_pointer args(
                     (starts_with(pvArguments->getStructure()->getID(), "epics:nt/NTURI:1.")) ?
-                        pvArguments->getStructureField("query") :
+                        pvArguments->getSubField<PVStructure>("query") :
                         pvArguments
                         );
 

--- a/testApp/remote/rpcServiceExample.cpp
+++ b/testApp/remote/rpcServiceExample.cpp
@@ -29,7 +29,7 @@ class SumServiceImpl :
         // NTURI support
         PVStructure::shared_pointer args(
                     (starts_with(pvArguments->getStructure()->getID(), "epics:nt/NTURI:1.")) ?
-                        pvArguments->getStructureField("query") :
+                        pvArguments->getSubField<PVStructure>("query") :
                         pvArguments
                         );
 

--- a/testApp/remote/testGetPerformance.cpp
+++ b/testApp/remote/testGetPerformance.cpp
@@ -295,7 +295,7 @@ void runTest()
     fields.push_back(getFieldCreate()->createScalar(pvInt));
     PVStructure::shared_pointer configuration =
         getPVDataCreate()->createPVStructure(getFieldCreate()->createStructure(fieldNames, fields));
-    configuration->getIntField("strategy")->put(bulkMode ? USER_CONTROLED : DELAYED);
+    configuration->getSubField<PVInt>("strategy")->put(bulkMode ? USER_CONTROLED : DELAYED);
     provider->configure(configuration);
     */
 

--- a/testApp/remote/testServer.cpp
+++ b/testApp/remote/testServer.cpp
@@ -86,7 +86,7 @@ static PVStructure::shared_pointer getRequestedStructure(
     {
         PVStructure::shared_pointer pvRequestFields;
         if (pvRequest->getSubField(subfieldName))
-            pvRequestFields = pvRequest->getStructureField(subfieldName);
+            pvRequestFields = pvRequest->getSubField<PVStructure>(subfieldName);
         else
             pvRequestFields = pvRequest;
 
@@ -203,7 +203,7 @@ public:
                     std::copy(shape->begin(), shape->end(), temp2.begin());
                     adcSimShape->replace(freeze(temp2));
 
-                    PVStructure::shared_pointer ts = adcMatrix->getStructureField("timeStamp");
+                    PVStructure::shared_pointer ts = adcMatrix->getSubField<PVStructure>("timeStamp");
 
                     PVTimeStamp timeStamp;
                     timeStamp.attach(ts);
@@ -384,7 +384,7 @@ static void generateNTTableDoubleValues(epics::pvData::PVStructure::shared_point
     PVStringArray::shared_pointer pvLabels = (static_pointer_cast<PVStringArray>(result->getScalarArrayField("labels", pvString)));
     PVStringArray::const_svector ld(pvLabels->view());
 
-    PVStructure::shared_pointer resultValue = result->getStructureField("value");
+    PVStructure::shared_pointer resultValue = result->getSubField<PVStructure>("value");
 
 #define ROWS 10
     double values[ROWS];
@@ -429,7 +429,7 @@ static void setTimeStamp(PVStructure::shared_pointer const & ts)
 
 static void generateNTAggregateValues(epics::pvData::PVStructure::shared_pointer result)
 {
-    setTimeStamp(result->getStructureField("firstTimeStamp"));
+    setTimeStamp(result->getSubField<PVStructure>("firstTimeStamp"));
 
 #define N 1024
     double values[N];
@@ -464,7 +464,7 @@ static void generateNTAggregateValues(epics::pvData::PVStructure::shared_pointer
     result->getSubField<PVLong>("N")->put(N);
 #undef N
 
-    setTimeStamp(result->getStructureField("lastTimeStamp"));
+    setTimeStamp(result->getSubField<PVStructure>("lastTimeStamp"));
 }
 
 
@@ -491,7 +491,7 @@ static void generateNTHistogramValues(epics::pvData::PVStructure::shared_pointer
     }
 #undef N
 
-    setTimeStamp(result->getStructureField("timeStamp"));
+    setTimeStamp(result->getSubField<PVStructure>("timeStamp"));
 }
 
 class ChannelFindRequesterImpl : public ChannelFindRequester
@@ -1213,7 +1213,7 @@ static bool handleHelp(
                         )
                     );
 
-        static_pointer_cast<PVString>(result->getStringField("value"))->put(helpText);
+        static_pointer_cast<PVString>(result->getSubField<PVString>("value"))->put(helpText);
         channelRPCRequester->requestDone(Status::Ok, channelRPC, result);
         return true;
     }
@@ -1289,7 +1289,7 @@ public:
         // handle NTURI request
         PVStructure::shared_pointer args(
                     (starts_with(pvArgument->getStructure()->getID(), "epics:nt/NTURI:1.")) ?
-                        pvArgument->getStructureField("query") :
+                        pvArgument->getSubField<PVStructure>("query") :
                         pvArgument
                         );
 
@@ -1549,7 +1549,7 @@ public:
             StructureConstPtr resultStructure = fieldCreate->createStructure(fieldNames, fields);
 
             PVStructure::shared_pointer result = getPVDataCreate()->createPVStructure(resultStructure);
-            result->getIntField("c")->put(a+b);
+            result->getSubField<PVInt>("c")->put(a+b);
 
             m_channelRPCRequester->requestDone(Status::Ok, shared_from_this(), result);
 
@@ -2203,13 +2203,13 @@ protected:
                 dimValue[0] = 0;
                 m_pvStructure->getSubField<PVIntArray>("dim")->replace(freeze(dimValue));
 
-                m_pvStructure->getStringField("descriptor")->put("Simulated ADC that provides NTMatrix value");
-                PVStructurePtr displayStructure = m_pvStructure->getStructureField("display");
-                displayStructure->getDoubleField("limitLow")->put(-1.0);
-                displayStructure->getDoubleField("limitHigh")->put(1.0);
-                displayStructure->getStringField("description")->put("Simulated ADC");
-                displayStructure->getStringField("format")->put("%f");
-                displayStructure->getStringField("units")->put("V");
+                m_pvStructure->getSubField<PVString>("descriptor")->put("Simulated ADC that provides NTMatrix value");
+                PVStructurePtr displayStructure = m_pvStructure->getSubField<PVStructure>("display");
+                displayStructure->getSubField<PVDouble>("limitLow")->put(-1.0);
+                displayStructure->getSubField<PVDouble>("limitHigh")->put(1.0);
+                displayStructure->getSubField<PVString>("description")->put("Simulated ADC");
+                displayStructure->getSubField<PVString>("format")->put("%f");
+                displayStructure->getSubField<PVString>("units")->put("V");
             }
             else if (m_name.find("testRPC") == 0 || m_name == "testNTTable" || m_name == "testNTMatrix")
             {
@@ -2305,7 +2305,7 @@ protected:
             {
                 string allProperties("alarm,timeStamp,display,control,valueAlarm");
                 m_pvStructure = getStandardPVField()->scalar(pvDouble,allProperties);
-                //PVDoublePtr pvField = m_pvStructure->getDoubleField(std::string("value"));
+                //PVDoublePtr pvField = m_pvStructure->getSubField<PVDouble>(std::string("value"));
                 //pvField->put(1.123);
             }
 


### PR DESCRIPTION
Corresponding changes for https://github.com/epics-base/pvDataCPP/pull/3