### PR TITLE
Make microbench library & header optional

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -30,5 +30,6 @@ endif
 
 ifdef WITH_MICROBENCH
 USR_CPPFLAGS += -DWITH_MICROBENCH
+MBLIB = pvMB
 endif
 

--- a/pvtoolsSrc/Makefile
+++ b/pvtoolsSrc/Makefile
@@ -4,24 +4,24 @@ include $(TOP)/configure/CONFIG
 
 PROD_HOST += pvget
 pvget_SRCS += pvget.cpp
-pvget_LIBS += pvAccess pvData pvMB ca Com
+pvget_LIBS += pvAccess pvData $(MBLIB) ca Com
 
 PROD_HOST += pvput
 pvput_SRCS += pvput.cpp
-pvput_LIBS += pvAccess pvData pvMB ca Com
+pvput_LIBS += pvAccess pvData $(MBLIB) ca Com
 
 PROD_HOST += pvinfo
 pvinfo_SRCS += pvinfo.cpp
-pvinfo_LIBS += pvAccess pvData pvMB ca Com
+pvinfo_LIBS += pvAccess pvData $(MBLIB) ca Com
 
 PROD_HOST += pvlist
 pvlist_SRCS += pvlist.cpp
-pvlist_LIBS += pvAccess pvData pvMB Com
+pvlist_LIBS += pvAccess pvData $(MBLIB) Com
 pvlist_SYS_LIBS_WIN32 += ws2_32
 
 PROD_HOST += eget
 eget_SRCS += eget.cpp
-eget_LIBS += pvAccess pvData pvMB ca Com
+eget_LIBS += pvAccess pvData $(MBLIB) ca Com
 
 include $(TOP)/configure/RULES
 #----------------------------------------

--- a/src/mb/pvAccessMB.h
+++ b/src/mb/pvAccessMB.h
@@ -6,7 +6,38 @@
 #   undef epicsExportSharedSymbols
 #endif
 
+#ifdef WITH_MICROBENCH
+
 #include <pv/mb.h>
+
+#else
+
+#define MB_DECLARE(NAME, SIZE)
+#define MB_DECLARE_EXTERN(NAME)
+
+#define MB_POINT_ID(NAME, STAGE, STAGE_DESC, ID)
+
+#define MB_INC_AUTO_ID(NAME)
+#define MB_POINT(NAME, STAGE, STAGE_DESC)
+
+#define MB_POINT_CONDITIONAL(NAME, STAGE, STAGE_DESC, COND)
+
+#define MB_NORMALIZE(NAME)
+
+#define MB_STATS(NAME, STREAM)
+#define MB_STATS_OPT(NAME, STAGE_ONLY, SKIP_FIRST_N_SAMPLES, STREAM)
+
+#define MB_CSV_EXPORT(NAME, STREAM)
+#define MB_CSV_EXPORT_OPT(NAME, STAGE_ONLY, SKIP_FIRST_N_SAMPLES, STREAM)
+#define MB_CSV_IMPORT(NAME, STREAM)
+
+#define MB_PRINT(NAME, STREAM)
+#define MB_PRINT_OPT(NAME, STAGE_ONLY, SKIP_FIRST_N_SAMPLES, STREAM)
+
+#define MB_INIT
+
+#endif
+
 
 #ifdef pvAccessMBEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols

--- a/testApp/Makefile
+++ b/testApp/Makefile
@@ -5,7 +5,7 @@ include $(TOP)/configure/CONFIG
 
 PVACCESS_TEST = $(TOP)/testApp
 
-PROD_LIBS += pvAccess pvData pvMB Com
+PROD_LIBS += pvAccess pvData $(MBLIB) Com
 
 include $(PVACCESS_TEST)/utils/Makefile
 include $(PVACCESS_TEST)/remote/Makefile


### PR DESCRIPTION
Requires related changes in pvaSrv, and in pvCommonCPP if you're actually using the microbench code.