### PR TITLE
Replace calls of deprecated PVStructure::getScalarArrayField

### DIFF
--- a/pvtoolsSrc/eget.cpp
+++ b/pvtoolsSrc/eget.cpp
@@ -328,7 +328,7 @@ void formatTable(std::ostream& o,
 
 void formatNTTable(std::ostream& o, PVStructurePtr const & pvStruct)
 {
-    PVStringArrayPtr labels = dynamic_pointer_cast<PVStringArray>(pvStruct->getScalarArrayField("labels", pvString));
+    PVStringArrayPtr labels = pvStruct->getSubField<PVStringArray>("labels");
     if (labels.get() == 0)
     {
         std::cerr << "no string[] 'labels' field in NTTable" << std::endl;
@@ -371,7 +371,7 @@ void formatNTTable(std::ostream& o, PVStructurePtr const & pvStruct)
 
 void formatNTMatrix(std::ostream& o, PVStructurePtr const & pvStruct)
 {
-    PVDoubleArrayPtr value = dynamic_pointer_cast<PVDoubleArray>(pvStruct->getScalarArrayField("value", pvDouble));
+    PVDoubleArrayPtr value = pvStruct->getSubField<PVDoubleArray>("value");
     if (value.get() == 0)
     {
         std::cerr << "no double[] 'value' field in NTMatrix" << std::endl;
@@ -380,7 +380,7 @@ void formatNTMatrix(std::ostream& o, PVStructurePtr const & pvStruct)
 
     int32 rows, cols;
 
-    PVIntArrayPtr dim = dynamic_pointer_cast<PVIntArray>(pvStruct->getScalarArrayField("dim", pvInt));
+    PVIntArrayPtr dim = pvStruct->getSubField<PVIntArray>("dim");
     if (dim.get() != 0)
     {
         // dim[] = { rows, columns }
@@ -479,7 +479,7 @@ void formatNTMatrix(std::ostream& o, PVStructurePtr const & pvStruct)
 // TODO use formatNTTable
 void formatNTNameValue(std::ostream& o, PVStructurePtr const & pvStruct)
 {
-    PVStringArrayPtr name = dynamic_pointer_cast<PVStringArray>(pvStruct->getScalarArrayField("name", pvString));
+    PVStringArrayPtr name = pvStruct->getSubField<PVStringArray>("name");
     if (name.get() == 0)
     {
         std::cerr << "no string[] 'name' field in NTNameValue" << std::endl;

--- a/src/ca/caChannel.cpp
+++ b/src/ca/caChannel.cpp
@@ -107,8 +107,7 @@ static PVStructure::shared_pointer createPVStructure(CAChannel::shared_pointer c
     PVStructure::shared_pointer pvStructure = getPVDataCreate()->createPVStructure(createStructure(channel, properties));
     if (channel->getNativeType() == DBR_ENUM)
     {
-
-        PVScalarArrayPtr pvScalarArray = pvStructure->getScalarArrayField("value.choices", pvString);
+        PVScalarArrayPtr pvScalarArray = pvStructure->getSubField<PVStringArray>("value.choices");
 
         // TODO avoid getting labels if DBR_GR_ENUM or DBR_CTRL_ENUM is used in subsequent get
         int result = ca_array_get_callback(DBR_GR_ENUM, 1, channel->getChannelID(), ca_get_labels_handler, pvScalarArray.get());
@@ -569,8 +568,7 @@ void copy_DBR(const void * dbr, unsigned count, PVStructure::shared_pointer cons
     }
     else
     {
-        std::tr1::shared_ptr<aF> value =
-                std::tr1::static_pointer_cast<aF>(pvStructure->getScalarArrayField("value", sT));
+        std::tr1::shared_ptr<aF> value = pvStructure->getSubField<aF>("value");
         typename aF::svector temp(value->reuse());
         temp.resize(count);
         std::copy(static_cast<const pT*>(dbr), static_cast<const pT*>(dbr) + count, temp.begin());
@@ -591,8 +589,7 @@ void copy_DBR<dbr_long_t, pvInt, PVInt, PVIntArray>(const void * dbr, unsigned c
     }
     else
     {
-        std::tr1::shared_ptr<PVIntArray> value =
-                std::tr1::static_pointer_cast<PVIntArray>(pvStructure->getScalarArrayField("value", pvInt));
+        std::tr1::shared_ptr<PVIntArray> value = pvStructure->getSubField<PVIntArray>("value");
         PVIntArray::svector temp(value->reuse());
         temp.resize(count);
         std::copy(static_cast<const int32*>(dbr), static_cast<const int32*>(dbr) + count, temp.begin());
@@ -612,8 +609,7 @@ void copy_DBR<string, pvString, PVString, PVStringArray>(const void * dbr, unsig
     }
     else
     {
-        std::tr1::shared_ptr<PVStringArray> value =
-                std::tr1::static_pointer_cast<PVStringArray>(pvStructure->getScalarArrayField("value", pvString));
+        std::tr1::shared_ptr<PVStringArray> value = pvStructure->getSubField<PVStringArray>("value");
         const dbr_string_t* dbrStrings = static_cast<const dbr_string_t*>(dbr);
         PVStringArray::svector sA(value->reuse());
         sA.resize(count);
@@ -1022,8 +1018,7 @@ int doPut_pvStructure(CAChannel::shared_pointer const & channel, void *usrArg, P
     }
     else
     {
-        std::tr1::shared_ptr<aF> value =
-                std::tr1::static_pointer_cast<aF>(pvStructure->getScalarArrayField("value", sT));
+        std::tr1::shared_ptr<aF> value = pvStructure->getSubField<aF>("value");
 
         const pT* val = value->view().data();
         int result = ca_array_put_callback(channel->getNativeType(), static_cast<unsigned long>(value->getLength()),
@@ -1063,8 +1058,7 @@ int doPut_pvStructure<string, pvString, PVString, PVStringArray>(CAChannel::shar
     }
     else
     {
-        std::tr1::shared_ptr<PVStringArray> value =
-                std::tr1::static_pointer_cast<PVStringArray>(pvStructure->getScalarArrayField("value", pvString));
+        std::tr1::shared_ptr<PVStringArray> value = pvStructure->getSubField<PVStringArray>("value");
 
         PVStringArray::const_svector stringArray(value->view());
 

--- a/testApp/remote/testServer.cpp
+++ b/testApp/remote/testServer.cpp
@@ -381,7 +381,7 @@ static epics::pvData::PVStructure::shared_pointer createNTHistogram()
 
 static void generateNTTableDoubleValues(epics::pvData::PVStructure::shared_pointer result)
 {
-    PVStringArray::shared_pointer pvLabels = (static_pointer_cast<PVStringArray>(result->getScalarArrayField("labels", pvString)));
+    PVStringArray::shared_pointer pvLabels = result->getSubField<PVStringArray>("labels");
     PVStringArray::const_svector ld(pvLabels->view());
 
     PVStructure::shared_pointer resultValue = result->getSubField<PVStructure>("value");
@@ -2110,7 +2110,7 @@ protected:
                 string allProperties("");
                 //            string allProperties("alarm,timeStamp,display,control");
                 m_pvStructure = getStandardPVField()->scalarArray(pvDouble,allProperties);
-                PVDoubleArrayPtr pvField = static_pointer_cast<PVDoubleArray>(m_pvStructure->getScalarArrayField(std::string("value"), pvDouble));
+                PVDoubleArrayPtr pvField = m_pvStructure->getSubField<PVDoubleArray>("value");
 
                 int specCount = 0; char postfix[64];
                 int done = sscanf(m_name.c_str(), "testArray%d%s", &specCount, postfix);


### PR DESCRIPTION
<p>Calls of the deprecated function PVStructure::getScalarArrayField have been replace by calls of the template function PVStructure::getSubField.
</p>

<p>This allows the ScalarType template parameter to be removed from the copy_DBR_XX functions in caChannel.cpp.
</p>