### PR TITLE
Specify pvRequest sent when creating ChannelRPC

### DIFF
--- a/src/rpcClient/rpcClient.cpp
+++ b/src/rpcClient/rpcClient.cpp
@@ -44,9 +44,14 @@ class ChannelAndRPCRequesterImpl :
     Status m_status;
     PVStructure::shared_pointer m_response;
     ChannelRPC::shared_pointer m_channelRPC;
+    PVStructure::shared_pointer m_pvRequest;
 
     public:
-    ChannelAndRPCRequesterImpl() {}
+
+    ChannelAndRPCRequesterImpl(PVStructure::shared_pointer const & pvRequest)
+    : m_pvRequest(pvRequest)
+    {
+    }
     
     virtual string getRequesterName()
     {
@@ -96,9 +101,7 @@ class ChannelAndRPCRequesterImpl :
 
             if (!rpcAlreadyConnectedOnce)
             {
-                PVStructure::shared_pointer pvRequest =
-                        CreateRequest::create()->createRequest("");
-                channel->createChannelRPC(shared_from_this(), pvRequest);
+                channel->createChannelRPC(shared_from_this(), m_pvRequest);
             }
         }
         /*
@@ -216,8 +219,9 @@ class ChannelAndRPCRequesterImpl :
 
 
 
-RPCClient::RPCClient(const std::string & serviceName)
-    : m_serviceName(serviceName)
+RPCClient::RPCClient(const std::string & serviceName,
+     PVStructure::shared_pointer const & pvRequest)
+    : m_serviceName(serviceName), m_pvRequest(pvRequest)
 {
 }
 
@@ -245,7 +249,7 @@ void RPCClient::issueConnect()
     ChannelProvider::shared_pointer provider = getChannelProviderRegistry()->getProvider("pva");
 
     // TODO try to reuse ChannelRequesterImpl instance (i.e. create only once)
-    shared_ptr<ChannelAndRPCRequesterImpl> channelRequesterImpl(new ChannelAndRPCRequesterImpl());
+    shared_ptr<ChannelAndRPCRequesterImpl> channelRequesterImpl(new ChannelAndRPCRequesterImpl(m_pvRequest));
     m_channel = provider->createChannel(m_serviceName, channelRequesterImpl);
 }
 
@@ -315,11 +319,17 @@ PVStructure::shared_pointer RPCClient::waitResponse(double timeout)
 
 RPCClient::shared_pointer RPCClient::create(const std::string & serviceName)
 {
-    ClientFactory::start();
-    
-    return RPCClient::shared_pointer(new RPCClient(serviceName));
+    PVStructure::shared_pointer pvRequest =
+        CreateRequest::create()->createRequest("");
+    return create(serviceName, pvRequest);
 }
 
+RPCClient::shared_pointer RPCClient::create(const std::string & serviceName,
+     PVStructure::shared_pointer const & pvRequest)
+{
+    ClientFactory::start(); 
+    return RPCClient::shared_pointer(new RPCClient(serviceName, pvRequest));
+}
 
 PVStructure::shared_pointer RPCClient::sendRequest(const std::string & serviceName,
      PVStructure::shared_pointer queryRequest,

--- a/src/rpcClient/rpcClient.h
+++ b/src/rpcClient/rpcClient.h
@@ -49,6 +49,16 @@ namespace pvAccess
         static shared_pointer create(const std::string & serviceName);
 
         /**
+         * Create a RPCClient.
+         *
+         * @param  serviceName  the service name
+         * @param  pvRequest    the pvRequest for the ChannelRPC
+         * @return              the RPCClient interface
+         */
+        static shared_pointer create(const std::string & serviceName,
+             epics::pvData::PVStructure::shared_pointer const & pvRequest);
+
+        /**
          * Performs complete blocking RPC call, opening a channel and connecting to the
          * service and sending the request.
          *
@@ -129,10 +139,12 @@ namespace pvAccess
         virtual ~RPCClient() {}
 
     protected:
-        RPCClient(const std::string & serviceName);
+        RPCClient(const std::string & serviceName,
+            epics::pvData::PVStructure::shared_pointer const & pvRequest);
 
         std::string m_serviceName;
         Channel::shared_pointer m_channel;
+        epics::pvData::PVStructure::shared_pointer m_pvRequest;
     };
 
 }


### PR DESCRIPTION
Add the ability to specify the pvRequest PVStructure sent when creating a Channel RPC using the pvAccess rpcClient library.

This is required for a Diamond middle-layer project where the channel name corresponds to a device. The operation for that device would then be specified when creating the ChannelRPC and the arguments for that operation in the ChannelRPC request itself.

RPCClient::create() is overloaded to allow the pvRequest to be specified whilst retaining the old default for convenience and backwards compatibility.

I have changed the signature of RPCClient's protected constructor. In theory this breaks absolute strict backwards compatibility, although I'm not aware of anyone inheriting from RPCClient. I can provide an overload of the constructor instead if this would be preferred.

