### PR TITLE
remove use of throw() specifier

### DIFF
--- a/documentation/pvAccessCPP.html
+++ b/documentation/pvAccessCPP.html
@@ -1370,7 +1370,7 @@ class  RPCService
     virtual ~RPCService() {};
     virtual PVStructurePtr request(
        PVStructurePtr const &amp; args
-    ) throw (RPCRequestException) = 0;
+    ) = 0;
 };
 
 

--- a/src/remote/pv/security.h
+++ b/src/remote/pv/security.h
@@ -138,8 +138,7 @@ namespace epics {
         virtual void close() = 0;
 
         // notification to the client on allowed requests (bitSet, a bit per request)
-        virtual ChannelSecuritySession::shared_pointer createChannelSession(std::string const & channelName)
-            throw (SecurityException) = 0;
+        virtual ChannelSecuritySession::shared_pointer createChannelSession(std::string const & channelName) = 0;
     };
 
     class epicsShareClass SecurityPluginControl {
@@ -197,7 +196,7 @@ namespace epics {
         virtual SecuritySession::shared_pointer createSession(
                 osiSockAddr const & remoteAddress,
                 SecurityPluginControl::shared_pointer const & control,
-                epics::pvData::PVField::shared_pointer const & data) throw (SecurityException) = 0;
+                epics::pvData::PVField::shared_pointer const & data) = 0;
     };
 
 
@@ -240,7 +239,6 @@ namespace epics {
 
         // notification to the client on allowed requests (bitSet, a bit per request)
         virtual ChannelSecuritySession::shared_pointer createChannelSession(std::string const & /*channelName*/)
-            throw (SecurityException)
         {
             return shared_from_this();
         }
@@ -284,7 +282,7 @@ namespace epics {
         virtual SecuritySession::shared_pointer createSession(
                 osiSockAddr const & /*remoteAddress*/,
                 SecurityPluginControl::shared_pointer const & control,
-                epics::pvData::PVField::shared_pointer const & /*data*/) throw (SecurityException) {
+                epics::pvData::PVField::shared_pointer const & /*data*/) {
             control->authenticationCompleted(epics::pvData::Status::Ok);
             return shared_from_this();
         }

--- a/src/rpcService/pv/rpcService.h
+++ b/src/rpcService/pv/rpcService.h
@@ -62,7 +62,7 @@ public:
  
     virtual epics::pvData::PVStructure::shared_pointer request(
         epics::pvData::PVStructure::shared_pointer const & args
-    ) throw (RPCRequestException) = 0;
+    ) = 0;
 };
 
 

--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -509,7 +509,7 @@ public:
 
     virtual epics::pvData::PVStructure::shared_pointer request(
         epics::pvData::PVStructure::shared_pointer const & arguments
-    ) throw (RPCRequestException)
+    )
     {
         // NTURI support
         PVStructure::shared_pointer args(

--- a/testApp/remote/rpcServiceExample.cpp
+++ b/testApp/remote/rpcServiceExample.cpp
@@ -24,7 +24,6 @@ class SumServiceImpl :
     public RPCService
 {
     PVStructure::shared_pointer request(PVStructure::shared_pointer const & pvArguments)
-        throw (RPCRequestException)
     {
         // NTURI support
         PVStructure::shared_pointer args(

--- a/testApp/remote/rpcWildServiceExample.cpp
+++ b/testApp/remote/rpcWildServiceExample.cpp
@@ -19,7 +19,6 @@ class WildServiceImpl :
     public RPCService
 {
     PVStructure::shared_pointer request(PVStructure::shared_pointer const & pvArguments)
-        throw (RPCRequestException)
     {
         // requires NTURI as argument
         if (pvArguments->getStructure()->getID() != "epics:nt/NTURI:1.0")


### PR DESCRIPTION
Function throw() specifiers in C++ have never been useful, and are deprecated in c++11.  In my mind almost[1] any use of this "feature" is a bug as the author probably did not understand the large difference in behavior between between c++ and java.  In java these are used for compile time checks, in c++ for runtime checks (like assert() complete with abort()).

[1] The "almost" is the use of throw() to indicate that no exception should ever be thrown.