### PR TITLE
bugfix for segfault when using pvaClientCPP

### DIFF
--- a/src/remoteClient/clientContextImpl.cpp
+++ b/src/remoteClient/clientContextImpl.cpp
@@ -2204,6 +2204,7 @@ namespace epics {
                    {
                        m_overrunInProgress = true;
                        m_overrunElement = newElement;
+                       return;
                    }
 
                    // setup current fields


### PR DESCRIPTION
This patch fixes the problem we've been seeing at SNS when pvaPy is using pvaClientCPP and eventually crashes. When running out of free pre-allocated pvStructures, the last one is used to somehow keep track of missed changes. But it must not be handed to user since it's modified by pvAccess whenever there's data, until there's at least one free pvStructure.