### PR TITLE
Make release 4.1.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+Release 4.1.3 
+==========
+
+* Monitor fix: element no longer queued when overrun in progress.
+
 Release 4.1.2 
 ==========
 

--- a/src/pva/pvaVersion.h
+++ b/src/pva/pvaVersion.h
@@ -27,7 +27,7 @@
 #define EPICS_PVA_MAJOR_VERSION 4
 #define EPICS_PVA_MINOR_VERSION 1
 #define EPICS_PVA_MAINTENANCE_VERSION 3
-#define EPICS_PVA_DEVELOPMENT_FLAG 1
+#define EPICS_PVA_DEVELOPMENT_FLAG 0
 
 namespace epics {
 namespace pvAccess {

--- a/src/pva/pvaVersion.h
+++ b/src/pva/pvaVersion.h
@@ -26,8 +26,8 @@
 // TODO to be generated, etc.
 #define EPICS_PVA_MAJOR_VERSION 4
 #define EPICS_PVA_MINOR_VERSION 1
-#define EPICS_PVA_MAINTENANCE_VERSION 2
-#define EPICS_PVA_DEVELOPMENT_FLAG 0
+#define EPICS_PVA_MAINTENANCE_VERSION 3
+#define EPICS_PVA_DEVELOPMENT_FLAG 1
 
 namespace epics {
 namespace pvAccess {

--- a/src/remoteClient/clientContextImpl.cpp
+++ b/src/remoteClient/clientContextImpl.cpp
@@ -2295,7 +2295,8 @@ namespace epics {
 
                    m_up2datePVStructure = pvStructure;
 
-                   m_monitorQueue.push(newElement);
+                   if (!m_overrunInProgress)
+                       m_monitorQueue.push(newElement);
                }
 
                if (!m_overrunInProgress)


### PR DESCRIPTION
Commits for 4.1.3 release with cherry-pick of monitor overrun double ref. fix fea2e1c26390158ec1a93c14abcde58a6ebc8101 onto release/4.1
