### PR TITLE
Move Monitor part 1

### DIFF
--- a/src/ca/caChannel.cpp
+++ b/src/ca/caChannel.cpp
@@ -363,8 +363,8 @@ ChannelRPC::shared_pointer CAChannel::createChannelRPC(
 }
 
 
-epics::pvData::Monitor::shared_pointer CAChannel::createMonitor(
-    epics::pvData::MonitorRequester::shared_pointer const & monitorRequester,
+Monitor::shared_pointer CAChannel::createMonitor(
+    MonitorRequester::shared_pointer const & monitorRequester,
     epics::pvData::PVStructure::shared_pointer const & pvRequest)
 {
     return CAChannelMonitor::create(shared_from_this(), monitorRequester, pvRequest);
@@ -1280,7 +1280,7 @@ void CAChannelPut::unlock()
 
 Monitor::shared_pointer CAChannelMonitor::create(
     CAChannel::shared_pointer const & channel,
-    epics::pvData::MonitorRequester::shared_pointer const & monitorRequester,
+    MonitorRequester::shared_pointer const & monitorRequester,
     epics::pvData::PVStructure::shared_pointer const & pvRequest)
 {
     // TODO use std::make_shared
@@ -1300,7 +1300,7 @@ CAChannelMonitor::~CAChannelMonitor()
 
 
 CAChannelMonitor::CAChannelMonitor(CAChannel::shared_pointer const & _channel,
-                                   epics::pvData::MonitorRequester::shared_pointer const & _monitorRequester,
+                                   MonitorRequester::shared_pointer const & _monitorRequester,
                                    epics::pvData::PVStructure::shared_pointer const & pvRequest) :
     channel(_channel),
     monitorRequester(_monitorRequester),
@@ -1329,7 +1329,7 @@ void CAChannelMonitor::activate()
 }
 
 
-/* --------------- epics::pvData::Monitor --------------- */
+/* --------------- Monitor --------------- */
 
 
 static void ca_subscription_handler(struct event_handler_args args)
@@ -1418,7 +1418,7 @@ epics::pvData::Status CAChannelMonitor::stop()
 }
 
 
-epics::pvData::MonitorElementPtr CAChannelMonitor::poll()
+MonitorElementPtr CAChannelMonitor::poll()
 {
     Lock lock(mutex);
     if (count)
@@ -1433,7 +1433,7 @@ epics::pvData::MonitorElementPtr CAChannelMonitor::poll()
 }
 
 
-void CAChannelMonitor::release(epics::pvData::MonitorElementPtr const & /*monitorElement*/)
+void CAChannelMonitor::release(MonitorElementPtr const & /*monitorElement*/)
 {
     // noop
 }

--- a/src/ca/pv/caChannel.h
+++ b/src/ca/pv/caChannel.h
@@ -73,8 +73,8 @@ public:
         ChannelRPCRequester::shared_pointer const & channelRPCRequester,
         epics::pvData::PVStructure::shared_pointer const & pvRequest);
 
-    virtual epics::pvData::Monitor::shared_pointer createMonitor(
-        epics::pvData::MonitorRequester::shared_pointer const & monitorRequester,
+    virtual Monitor::shared_pointer createMonitor(
+        MonitorRequester::shared_pointer const & monitorRequester,
         epics::pvData::PVStructure::shared_pointer const & pvRequest);
 
     virtual ChannelArray::shared_pointer createChannelArray(
@@ -243,27 +243,27 @@ private:
 
 
 class CAChannelMonitor :
-    public epics::pvData::Monitor,
+    public Monitor,
     public std::tr1::enable_shared_from_this<CAChannelMonitor>
 {
 
 public:
     POINTER_DEFINITIONS(CAChannelMonitor);
 
-    static epics::pvData::Monitor::shared_pointer create(CAChannel::shared_pointer const & channel,
-            epics::pvData::MonitorRequester::shared_pointer const & monitorRequester,
+    static Monitor::shared_pointer create(CAChannel::shared_pointer const & channel,
+            MonitorRequester::shared_pointer const & monitorRequester,
             epics::pvData::PVStructure::shared_pointer const & pvRequest);
 
     virtual ~CAChannelMonitor();
 
     void subscriptionEvent(struct event_handler_args &args);
 
-    /* --------------- epics::pvData::Monitor --------------- */
+    /* --------------- Monitor --------------- */
 
     virtual epics::pvData::Status start();
     virtual epics::pvData::Status stop();
-    virtual epics::pvData::MonitorElementPtr poll();
-    virtual void release(epics::pvData::MonitorElementPtr const & monitorElement);
+    virtual MonitorElementPtr poll();
+    virtual void release(MonitorElementPtr const & monitorElement);
 
     /* --------------- epics::pvData::ChannelRequest --------------- */
 
@@ -276,12 +276,12 @@ public:
 private:
 
     CAChannelMonitor(CAChannel::shared_pointer const & _channel,
-                     epics::pvData::MonitorRequester::shared_pointer const & _monitorRequester,
+                     MonitorRequester::shared_pointer const & _monitorRequester,
                      epics::pvData::PVStructure::shared_pointer const & pvRequest);
     void activate();
 
     CAChannel::shared_pointer channel;
-    epics::pvData::MonitorRequester::shared_pointer monitorRequester;
+    MonitorRequester::shared_pointer monitorRequester;
     chtype getType;
 
     epics::pvData::PVStructure::shared_pointer pvStructure;
@@ -292,8 +292,8 @@ private:
     epics::pvData::Mutex mutex;
     int count;
 
-    epics::pvData::MonitorElement::shared_pointer element;
-    epics::pvData::MonitorElement::shared_pointer nullElement;
+    MonitorElement::shared_pointer element;
+    MonitorElement::shared_pointer nullElement;
 
     // TODO remove
     Monitor::shared_pointer thisPointer;

--- a/src/client/pv/pvAccess.h
+++ b/src/client/pv/pvAccess.h
@@ -34,6 +34,17 @@ namespace epics {
 namespace pvAccess {
 class Configuration;
 
+using epics::pvData::Requester;
+using epics::pvData::RequesterPtr;
+using epics::pvData::MessageType;
+using epics::pvData::getMessageTypeName;
+
+using epics::pvData::MonitorElement;
+using epics::pvData::MonitorElementPtr;
+using epics::pvData::MonitorElementPtrArray;
+using epics::pvData::Monitor;
+using epics::pvData::MonitorRequester;
+
 // TODO add write-only?
 // change names
 enum AccessRights {

--- a/src/client/pv/pvAccess.h
+++ b/src/client/pv/pvAccess.h
@@ -190,9 +190,9 @@ public:
 };
 
 /**
- * The epics::pvData::Requester for a ChannelArray.
+ * The Requester for a ChannelArray.
  */
-class epicsShareClass ChannelArrayRequester : virtual public epics::pvData::Requester {
+class epicsShareClass ChannelArrayRequester : virtual public Requester {
 public:
     POINTER_DEFINITIONS(ChannelArrayRequester);
 
@@ -313,9 +313,9 @@ public:
 
 
 /**
- * epics::pvData::Requester for channelGet.
+ * Requester for channelGet.
  */
-class epicsShareClass ChannelGetRequester : virtual public epics::pvData::Requester {
+class epicsShareClass ChannelGetRequester : virtual public Requester {
 public:
     POINTER_DEFINITIONS(ChannelGetRequester);
 
@@ -361,9 +361,9 @@ public:
 
 
 /**
- * epics::pvData::Requester for channelProcess.
+ * Requester for channelProcess.
  */
-class epicsShareClass ChannelProcessRequester : virtual public epics::pvData::Requester {
+class epicsShareClass ChannelProcessRequester : virtual public Requester {
 public:
     POINTER_DEFINITIONS(ChannelProcessRequester);
 
@@ -413,9 +413,9 @@ public:
 };
 
 /**
- * epics::pvData::Requester for ChannelPut.
+ * Requester for ChannelPut.
  */
-class epicsShareClass ChannelPutRequester : virtual public epics::pvData::Requester {
+class epicsShareClass ChannelPutRequester : virtual public Requester {
 public:
     POINTER_DEFINITIONS(ChannelPutRequester);
 
@@ -487,9 +487,9 @@ public:
 
 
 /**
- * epics::pvData::Requester for ChannelPutGet.
+ * Requester for ChannelPutGet.
  */
-class epicsShareClass ChannelPutGetRequester : virtual public epics::pvData::Requester
+class epicsShareClass ChannelPutGetRequester : virtual public Requester
 {
 public:
     POINTER_DEFINITIONS(ChannelPutGetRequester);
@@ -549,7 +549,7 @@ public:
 
 
 /**
- * epics::pvData::Requester for channelGet.
+ * Requester for channelGet.
  */
 class epicsShareClass ChannelRPC : public ChannelRequest {
 public:
@@ -565,9 +565,9 @@ public:
 
 
 /**
- * epics::pvData::Requester for channelGet.
+ * Requester for channelGet.
  */
-class epicsShareClass ChannelRPCRequester : virtual public epics::pvData::Requester {
+class epicsShareClass ChannelRPCRequester : virtual public Requester {
 public:
     POINTER_DEFINITIONS(ChannelRPCRequester);
 
@@ -594,9 +594,9 @@ public:
 
 
 /**
- * epics::pvData::Requester for a getStructure request.
+ * Requester for a getStructure request.
  */
-class epicsShareClass GetFieldRequester : virtual public epics::pvData::Requester {
+class epicsShareClass GetFieldRequester : virtual public Requester {
 public:
     POINTER_DEFINITIONS(GetFieldRequester);
 
@@ -619,7 +619,7 @@ class ChannelRequester;
  * A channel is created via a call to ChannelAccess.createChannel(std::string channelName).
  */
 class epicsShareClass Channel :
-    public epics::pvData::Requester,
+    public Requester,
     public epics::pvData::Destroyable,
     private epics::pvData::NoDefaultMethods {
 public:
@@ -665,8 +665,8 @@ public:
     virtual std::string getChannelName() = 0;
 
     /**
-     * Get the channel epics::pvData::Requester.
-     * @return The epics::pvData::Requester.
+     * Get the channel Requester.
+     * @return The Requester.
      */
 //            virtual ChannelRequester::shared_pointer getChannelRequester() = 0;
     virtual std::tr1::shared_ptr<ChannelRequester> getChannelRequester() = 0;
@@ -681,7 +681,7 @@ public:
      * Get a Field which describes the subField.
      * GetFieldRequester.getDone is called after both client and server have processed the getField request.
      * This is for clients that want to introspect a PVRecord via channel access.
-     * @param epics::pvData::Requester The epics::pvData::Requester.
+     * @param Requester The Requester.
      * @param subField The name of the subField.
      * If this is null or an empty std::string the returned Field is for the entire record.
      */
@@ -752,7 +752,7 @@ public:
 
     /**
      * Create a ChannelRPC (Remote Procedure Call).
-     * @param channelRPCRequester The epics::pvData::Requester.
+     * @param channelRPCRequester The Requester.
      * @param pvRequest Request options.
      * @return <code>ChannelRPC</code> instance.
      */
@@ -762,13 +762,13 @@ public:
 
     /**
      * Create a Monitor.
-     * @param monitorRequester The epics::pvData::Requester.
+     * @param monitorRequester The Requester.
      * @param pvRequest A structure describing the desired set of fields from the remote PVRecord.
      * This has the same form as a pvRequest to PVCopyFactory.create.
      * @return <code>Monitor</code> instance.
      */
-    virtual epics::pvData::Monitor::shared_pointer createMonitor(
-        epics::pvData::MonitorRequester::shared_pointer const & monitorRequester,
+    virtual Monitor::shared_pointer createMonitor(
+        MonitorRequester::shared_pointer const & monitorRequester,
         epics::pvData::PVStructure::shared_pointer const & pvRequest) = 0;
 
     /**
@@ -797,7 +797,7 @@ public:
 /**
  * Listener for connect state changes.
  */
-class epicsShareClass ChannelRequester : public virtual epics::pvData::Requester {
+class epicsShareClass ChannelRequester : public virtual Requester {
 public:
     POINTER_DEFINITIONS(ChannelRequester);
 
@@ -853,7 +853,7 @@ public:
     /**
      * Find a channel.
      * @param channelName The channel name.
-     * @param channelFindRequester The epics::pvData::Requester.
+     * @param channelFindRequester The Requester.
      * @return An interface for the find.
      */
     virtual ChannelFind::shared_pointer channelFind(std::string const & channelName,
@@ -861,7 +861,7 @@ public:
 
     /**
      * Find channels.
-     * @param channelFindRequester The epics::pvData::Requester.
+     * @param channelFindRequester The Requester.
      * @return An interface for the find.
      */
     virtual ChannelFind::shared_pointer channelList(ChannelListRequester::shared_pointer const & channelListRequester) = 0;
@@ -869,7 +869,7 @@ public:
     /**
      * Create a channel.
      * @param channelName The name of the channel.
-     * @param channelRequester The epics::pvData::Requester.
+     * @param channelRequester The Requester.
      * @param priority channel priority, must be <code>PRIORITY_MIN</code> <= priority <= <code>PRIORITY_MAX</code>.
      * @return <code>Channel</code> instance. If channel does not exist <code>null</code> is returned and <code>channelRequester</code> notified.
      */
@@ -879,7 +879,7 @@ public:
     /**
      * Create a channel.
      * @param channelName The name of the channel.
-     * @param channelRequester The epics::pvData::Requester.
+     * @param channelRequester The Requester.
      * @param priority channel priority, must be <code>PRIORITY_MIN</code> <= priority <= <code>PRIORITY_MAX</code>.
      * @param address address (or list of addresses) where to look for a channel. Implementation independed std::string.
      * @return <code>Channel</code> instance. If channel does not exist <code>null</code> is returned and <code>channelRequester</code> notified.
@@ -972,7 +972,7 @@ epicsShareExtern void unregisterChannelProviderFactory(ChannelProviderFactory::s
  * @brief Pipeline (streaming) support API (optional).
  * This is used by pvAccess to implement pipeline (streaming) monitors.
  */
-class epicsShareClass PipelineMonitor : public virtual epics::pvData::Monitor {
+class epicsShareClass PipelineMonitor : public virtual Monitor {
 public:
     POINTER_DEFINITIONS(PipelineMonitor);
     virtual ~PipelineMonitor() {}

--- a/src/pipelineService/pipelineServer.cpp
+++ b/src/pipelineService/pipelineServer.cpp
@@ -250,7 +250,7 @@ public:
         return m_requestedCount;
     }
 
-    virtual epics::pvData::MonitorElement::shared_pointer getFreeElement() {
+    virtual MonitorElement::shared_pointer getFreeElement() {
         Lock guard(m_freeQueueLock);
         if (m_freeQueue.empty())
             return m_nullMonitorElement;
@@ -261,7 +261,7 @@ public:
         return freeElement;
     }
 
-    virtual void putElement(epics::pvData::MonitorElement::shared_pointer const & element) {
+    virtual void putElement(MonitorElement::shared_pointer const & element) {
 
         bool notify = false;
         {
@@ -430,8 +430,8 @@ public:
         return nullPtr;
     }
 
-    virtual epics::pvData::Monitor::shared_pointer createMonitor(
-        epics::pvData::MonitorRequester::shared_pointer const & monitorRequester,
+    virtual Monitor::shared_pointer createMonitor(
+        MonitorRequester::shared_pointer const & monitorRequester,
         epics::pvData::PVStructure::shared_pointer const & pvRequest)
     {
         if (!pvRequest)

--- a/src/pipelineService/pv/pipelineService.h
+++ b/src/pipelineService/pv/pipelineService.h
@@ -47,10 +47,10 @@ public:
     /// Grab next free element.
     /// A service should take this element, populate it with the data
     /// and return it back by calling putElement().
-    virtual epics::pvData::MonitorElement::shared_pointer getFreeElement() = 0;
+    virtual MonitorElement::shared_pointer getFreeElement() = 0;
 
     /// Put element on the local queue (an element to be sent to a client).
-    virtual void putElement(epics::pvData::MonitorElement::shared_pointer const & element) = 0;
+    virtual void putElement(MonitorElement::shared_pointer const & element) = 0;
 
     /// Call to notify that there is no more data to pipelined.
     /// This call destroyes corresponding pipeline session.

--- a/src/remoteClient/clientContextImpl.cpp
+++ b/src/remoteClient/clientContextImpl.cpp
@@ -4254,8 +4254,8 @@ private:
             return ChannelRPCImpl::create(shared_from_this(), channelRPCRequester, pvRequest);
         }
 
-        virtual epics::pvData::Monitor::shared_pointer createMonitor(
-            epics::pvData::MonitorRequester::shared_pointer const & monitorRequester,
+        virtual Monitor::shared_pointer createMonitor(
+            MonitorRequester::shared_pointer const & monitorRequester,
             epics::pvData::PVStructure::shared_pointer const & pvRequest)
         {
             return ChannelMonitorImpl::create(shared_from_this(), monitorRequester, pvRequest);

--- a/src/server/pv/responseHandlers.h
+++ b/src/server/pv/responseHandlers.h
@@ -510,7 +510,7 @@ public:
 
 class ServerMonitorRequesterImpl :
     public BaseChannelRequester,
-    public epics::pvData::MonitorRequester,
+    public MonitorRequester,
     public TransportSender,
     public std::tr1::enable_shared_from_this<ServerMonitorRequesterImpl>
 {
@@ -523,22 +523,22 @@ protected:
                                Transport::shared_pointer const & transport);
     void activate(epics::pvData::PVStructure::shared_pointer const & pvRequest);
 public:
-    static epics::pvData::MonitorRequester::shared_pointer create(ServerContextImpl::shared_pointer const & context,
+    static MonitorRequester::shared_pointer create(ServerContextImpl::shared_pointer const & context,
             ServerChannelImpl::shared_pointer const & channel, const pvAccessID ioid,
             Transport::shared_pointer const & transport,epics::pvData::PVStructure::shared_pointer const & pvRequest);
     virtual ~ServerMonitorRequesterImpl() {}
 
-    void monitorConnect(const epics::pvData::Status& status, epics::pvData::Monitor::shared_pointer const & monitor, epics::pvData::StructureConstPtr const & structure);
-    void unlisten(epics::pvData::Monitor::shared_pointer const & monitor);
-    void monitorEvent(epics::pvData::Monitor::shared_pointer const & monitor);
+    void monitorConnect(const epics::pvData::Status& status, Monitor::shared_pointer const & monitor, epics::pvData::StructureConstPtr const & structure);
+    void unlisten(Monitor::shared_pointer const & monitor);
+    void monitorEvent(Monitor::shared_pointer const & monitor);
     void lock();
     void unlock();
     void destroy();
 
-    epics::pvData::Monitor::shared_pointer getChannelMonitor();
+    Monitor::shared_pointer getChannelMonitor();
     void send(epics::pvData::ByteBuffer* buffer, TransportSendControl* control);
 private:
-    epics::pvData::Monitor::shared_pointer _channelMonitor;
+    Monitor::shared_pointer _channelMonitor;
     epics::pvData::StructureConstPtr _structure;
     epics::pvData::Status _status;
     bool _unlisten;

--- a/testApp/remote/testServer.cpp
+++ b/testApp/remote/testServer.cpp
@@ -2496,8 +2496,8 @@ public:
         return MockChannelRPC::create(channelRPCRequester, shared_from_this(), m_pvStructure, pvRequest);
     }
 
-    virtual epics::pvData::Monitor::shared_pointer createMonitor(
-        epics::pvData::MonitorRequester::shared_pointer const & monitorRequester,
+    virtual Monitor::shared_pointer createMonitor(
+        MonitorRequester::shared_pointer const & monitorRequester,
         epics::pvData::PVStructure::shared_pointer const & pvRequest)
     {
         return MockMonitor::create(m_name, monitorRequester, m_pvStructure, pvRequest);


### PR DESCRIPTION
First phase of epics-base/pvDataCPP#35 which adds aliases to the pvAccess namespace (see 15449dde6be3ab9ddf5fc56de0fa25c5a827f5ca).  Switches code in pvAccessCPP to use the aliased names.