### PR TITLE
Channel defaults

### DIFF
--- a/src/ca/caChannel.cpp
+++ b/src/ca/caChannel.cpp
@@ -277,13 +277,6 @@ std::tr1::shared_ptr<ChannelRequester> CAChannel::getChannelRequester()
     return channelRequester;
 }
 
-
-bool CAChannel::isConnected()
-{
-    return (ca_state(channelID) == cs_conn);
-}
-
-
 void CAChannel::getField(GetFieldRequester::shared_pointer const & requester,
                          std::string const & subField)
 {
@@ -383,12 +376,6 @@ ChannelArray::shared_pointer CAChannel::createChannelArray(
 }
 
 
-void CAChannel::printInfo()
-{
-    printInfo(std::cout);
-}
-
-
 void CAChannel::printInfo(std::ostream& out)
 {
     out << "CHANNEL  : " << getChannelName() << std::endl;
@@ -400,21 +387,6 @@ void CAChannel::printInfo(std::ostream& out)
         out << "ADDRESS  : " << getRemoteAddress() << std::endl;
         //out << "RIGHTS   : " << getAccessRights() << std::endl;
     }
-}
-
-
-/* --------------- epics::pvData::Requester --------------- */
-
-
-string CAChannel::getRequesterName()
-{
-    return getChannelName();
-}
-
-
-void CAChannel::message(std::string const & message,MessageType messageType)
-{
-    std::cout << "[" << getRequesterName() << "] message(" << message << ", " << getMessageTypeName(messageType) << ")" << std::endl;
 }
 
 

--- a/src/ca/pv/caChannel.h
+++ b/src/ca/pv/caChannel.h
@@ -47,7 +47,6 @@ public:
     virtual ConnectionState getConnectionState();
     virtual std::string getChannelName();
     virtual std::tr1::shared_ptr<ChannelRequester> getChannelRequester();
-    virtual bool isConnected();
 
     virtual void getField(GetFieldRequester::shared_pointer const & requester,std::string const & subField);
 
@@ -81,15 +80,7 @@ public:
         ChannelArrayRequester::shared_pointer const & channelArrayRequester,
         epics::pvData::PVStructure::shared_pointer const & pvRequest);
 
-    virtual void printInfo();
-
     virtual void printInfo(std::ostream& out);
-
-    /* --------------- epics::pvData::Requester --------------- */
-
-    virtual std::string getRequesterName();
-
-    virtual void message(std::string const & message, epics::pvData::MessageType messageType);
 
     /* --------------- epics::pvData::Destroyable --------------- */
 

--- a/src/client/pv/pvAccess.h
+++ b/src/client/pv/pvAccess.h
@@ -616,6 +616,9 @@ public:
 
     virtual ~Channel() {}
 
+    virtual std::string getRequesterName();
+    virtual void message(std::string const & message, epics::pvData::MessageType messageType);
+
     /**
      * Channel connection status.
      */
@@ -664,7 +667,7 @@ public:
      * Is the channel connected?
      * @return (false,true) means (not, is) connected.
      */
-    virtual bool isConnected() = 0;
+    virtual bool isConnected() { return getConnectionState()==CONNECTED; }
 
     /**
      * Get a Field which describes the subField.
@@ -695,7 +698,7 @@ public:
      */
     virtual ChannelProcess::shared_pointer createChannelProcess(
         ChannelProcessRequester::shared_pointer const & channelProcessRequester,
-        epics::pvData::PVStructure::shared_pointer const & pvRequest) = 0;
+        epics::pvData::PVStructure::shared_pointer const & pvRequest);
 
     /**
      * Create a ChannelGet.
@@ -709,7 +712,7 @@ public:
      */
     virtual ChannelGet::shared_pointer createChannelGet(
         ChannelGetRequester::shared_pointer const & channelGetRequester,
-        epics::pvData::PVStructure::shared_pointer const & pvRequest) = 0;
+        epics::pvData::PVStructure::shared_pointer const & pvRequest);
 
     /**
      * Create a ChannelPut.
@@ -723,7 +726,7 @@ public:
      */
     virtual ChannelPut::shared_pointer createChannelPut(
         ChannelPutRequester::shared_pointer const & channelPutRequester,
-        epics::pvData::PVStructure::shared_pointer const & pvRequest) = 0;
+        epics::pvData::PVStructure::shared_pointer const & pvRequest);
 
     /**
      * Create a ChannelPutGet.
@@ -737,7 +740,7 @@ public:
      */
     virtual ChannelPutGet::shared_pointer createChannelPutGet(
         ChannelPutGetRequester::shared_pointer const & channelPutGetRequester,
-        epics::pvData::PVStructure::shared_pointer const & pvRequest) = 0;
+        epics::pvData::PVStructure::shared_pointer const & pvRequest);
 
     /**
      * Create a ChannelRPC (Remote Procedure Call).
@@ -747,7 +750,7 @@ public:
      */
     virtual ChannelRPC::shared_pointer createChannelRPC(
         ChannelRPCRequester::shared_pointer const & channelRPCRequester,
-        epics::pvData::PVStructure::shared_pointer const & pvRequest) = 0;
+        epics::pvData::PVStructure::shared_pointer const & pvRequest);
 
     /**
      * Create a Monitor.
@@ -758,7 +761,7 @@ public:
      */
     virtual epics::pvData::Monitor::shared_pointer createMonitor(
         epics::pvData::MonitorRequester::shared_pointer const & monitorRequester,
-        epics::pvData::PVStructure::shared_pointer const & pvRequest) = 0;
+        epics::pvData::PVStructure::shared_pointer const & pvRequest);
 
     /**
      * Create a ChannelArray.
@@ -768,18 +771,18 @@ public:
      */
     virtual ChannelArray::shared_pointer createChannelArray(
         ChannelArrayRequester::shared_pointer const & channelArrayRequester,
-        epics::pvData::PVStructure::shared_pointer const & pvRequest) = 0;
+        epics::pvData::PVStructure::shared_pointer const & pvRequest);
 
     /**
      * Prints detailed information about the context to the standard output stream.
      */
-    virtual void printInfo() = 0;
+    virtual void printInfo() { printInfo(std::cout); }
 
     /**
      * Prints detailed information about the context to the specified output stream.
      * @param out the output stream.
      */
-    virtual void printInfo(std::ostream& out) = 0;
+    virtual void printInfo(std::ostream& out) {}
 };
 
 

--- a/src/client/pvAccess.cpp
+++ b/src/client/pvAccess.cpp
@@ -7,10 +7,98 @@
 #define epicsExportSharedSymbols
 #include <pv/pvAccess.h>
 
+namespace pvd = epics::pvData;
+
 namespace epics {
 namespace pvAccess {
 
 const char* Channel::ConnectionStateNames[] = { "NEVER_CONNECTED", "CONNECTED", "DISCONNECTED", "DESTROYED" };
+
+std::string Channel::getRequesterName()
+{
+    std::tr1::shared_ptr<ChannelRequester> req(getChannelRequester());
+    return req ? req->getRequesterName() : std::string("<Destroy'd Channel>");
+}
+
+void Channel::message(std::string const & message, epics::pvData::MessageType messageType)
+{
+    std::tr1::shared_ptr<ChannelRequester> req(getChannelRequester());
+    if(req) {
+        req->message(message, messageType);
+    } else {
+        std::cerr<<epics::pvData::getMessageTypeName(messageType)
+                 <<": on Destroy'd Channel \""<<getChannelName()
+                 <<"\" : "<<message;
+    }
+}
+
+ChannelProcess::shared_pointer Channel::createChannelProcess(
+        ChannelProcessRequester::shared_pointer const & requester,
+        epics::pvData::PVStructure::shared_pointer const & pvRequest)
+{
+    ChannelProcess::shared_pointer ret;
+    requester->channelProcessConnect(pvd::Status(pvd::Status::STATUSTYPE_FATAL, "Not Implemented"), ret);
+    return ret;
+}
+
+ChannelGet::shared_pointer Channel::createChannelGet(
+        ChannelGetRequester::shared_pointer const & requester,
+        epics::pvData::PVStructure::shared_pointer const & pvRequest)
+{
+    ChannelGet::shared_pointer ret;
+    requester->channelGetConnect(pvd::Status(pvd::Status::STATUSTYPE_FATAL, "Not Implemented"),
+                                 ret, pvd::StructureConstPtr());
+    return ret;
+}
+
+ChannelPut::shared_pointer Channel::createChannelPut(
+        ChannelPutRequester::shared_pointer const & requester,
+        epics::pvData::PVStructure::shared_pointer const & pvRequest)
+{
+    ChannelPut::shared_pointer ret;
+    requester->channelPutConnect(pvd::Status(pvd::Status::STATUSTYPE_FATAL, "Not Implemented"),
+                                 ret, pvd::StructureConstPtr());
+    return ret;
+}
+
+ChannelPutGet::shared_pointer Channel::createChannelPutGet(
+        ChannelPutGetRequester::shared_pointer const & requester,
+        epics::pvData::PVStructure::shared_pointer const & pvRequest)
+{
+    ChannelPutGet::shared_pointer ret;
+    requester->channelPutGetConnect(pvd::Status(pvd::Status::STATUSTYPE_FATAL, "Not Implemented"),
+                                    ret, pvd::StructureConstPtr(), pvd::StructureConstPtr());
+    return ret;
+}
+
+ChannelRPC::shared_pointer Channel::createChannelRPC(
+        ChannelRPCRequester::shared_pointer const & requester,
+        epics::pvData::PVStructure::shared_pointer const & pvRequest)
+{
+    ChannelRPC::shared_pointer ret;
+    requester->channelRPCConnect(pvd::Status(pvd::Status::STATUSTYPE_FATAL, "Not Implemented"), ret);
+    return ret;
+}
+
+pvd::Monitor::shared_pointer Channel::createMonitor(
+        epics::pvData::MonitorRequester::shared_pointer const & requester,
+        epics::pvData::PVStructure::shared_pointer const & pvRequest)
+{
+    pvd::Monitor::shared_pointer ret;
+    requester->monitorConnect(pvd::Status(pvd::Status::STATUSTYPE_FATAL, "Not Implemented"),
+                              ret, pvd::StructureConstPtr());
+    return ret;
+}
+
+ChannelArray::shared_pointer Channel::createChannelArray(
+        ChannelArrayRequester::shared_pointer const & requester,
+        epics::pvData::PVStructure::shared_pointer const & pvRequest)
+{
+    ChannelArray::shared_pointer ret;
+    requester->channelArrayConnect(pvd::Status(pvd::Status::STATUSTYPE_FATAL, "Not Implemented"),
+                                   ret, pvd::Array::const_shared_pointer());
+    return ret;
+}
 
 }
 }


### PR DESCRIPTION
Provide and use a default implementation for some Channel methods.  Default Requester methods forward to associated ChannelRequester, default create*() methods which fail with "Not Implemented", and default no-op printInfo().

The aim is to reduce the amount of boilerplate someone writing a new ChannelProvider has to add.