### PR TITLE
Add requester_type and operation_type

### DIFF
--- a/src/client/pv/pvAccess.h
+++ b/src/client/pv/pvAccess.h
@@ -108,6 +108,13 @@ private:
 
 class Channel;
 class ChannelProvider;
+class ChannelArrayRequester;
+class ChannelFindRequester;
+class ChannelGetRequester;
+class ChannelProcessRequester;
+class ChannelPutRequester;
+class ChannelPutGetRequester;
+class ChannelRPCRequester;
 
 /**
  * Base interface for all channel requests.
@@ -146,6 +153,7 @@ public:
 class epicsShareClass ChannelArray : public ChannelRequest {
 public:
     POINTER_DEFINITIONS(ChannelArray);
+    typedef ChannelArrayRequester requester_type;
 
     /**
      * put to the remote array.
@@ -184,6 +192,7 @@ public:
 class epicsShareClass ChannelArrayRequester : virtual public epics::pvData::Requester {
 public:
     POINTER_DEFINITIONS(ChannelArrayRequester);
+    typedef ChannelArray operation_type;
 
     /**
      * The client and server have both completed the createChannelArray request.
@@ -244,6 +253,7 @@ public:
 class epicsShareClass ChannelFind : public epics::pvData::Destroyable, private epics::pvData::NoDefaultMethods {
 public:
     POINTER_DEFINITIONS(ChannelFind);
+    typedef ChannelFindRequester requester_type;
 
     virtual std::tr1::shared_ptr<ChannelProvider> getChannelProvider() = 0;
     virtual void cancel() = 0;
@@ -255,6 +265,7 @@ public:
 class epicsShareClass ChannelFindRequester {
 public:
     POINTER_DEFINITIONS(ChannelFindRequester);
+    typedef ChannelFind operation_type;
 
     virtual ~ChannelFindRequester() {};
 
@@ -273,6 +284,7 @@ public:
 class epicsShareClass ChannelListRequester {
 public:
     POINTER_DEFINITIONS(ChannelListRequester);
+    typedef ChannelFind operation_type;
 
     virtual ~ChannelListRequester() {};
 
@@ -292,6 +304,7 @@ public:
 class epicsShareClass ChannelGet : public ChannelRequest {
 public:
     POINTER_DEFINITIONS(ChannelGet);
+    typedef ChannelGetRequester requester_type;
 
     /**
      * Get data from the channel.
@@ -307,6 +320,7 @@ public:
 class epicsShareClass ChannelGetRequester : virtual public epics::pvData::Requester {
 public:
     POINTER_DEFINITIONS(ChannelGetRequester);
+    typedef ChannelGet operation_type;
 
     /**
      * The client and server have both completed the createChannelGet request.
@@ -340,6 +354,7 @@ public:
 class epicsShareClass ChannelProcess : public ChannelRequest {
 public:
     POINTER_DEFINITIONS(ChannelProcess);
+    typedef ChannelProcessRequester requester_type;
 
     /**
      * Issue a process request.
@@ -355,6 +370,7 @@ public:
 class epicsShareClass ChannelProcessRequester : virtual public epics::pvData::Requester {
 public:
     POINTER_DEFINITIONS(ChannelProcessRequester);
+    typedef ChannelProcess operation_type;
 
     /**
      * The client and server have both completed the createChannelProcess request.
@@ -383,6 +399,7 @@ public:
 class epicsShareClass ChannelPut : public ChannelRequest {
 public:
     POINTER_DEFINITIONS(ChannelPut);
+    typedef ChannelPutRequester requester_type;
 
     /**
      * Put data to a channel.
@@ -407,6 +424,7 @@ public:
 class epicsShareClass ChannelPutRequester : virtual public epics::pvData::Requester {
 public:
     POINTER_DEFINITIONS(ChannelPutRequester);
+    typedef ChannelPut operation_type;
 
     /**
      * The client and server have both processed the createChannelPut request.
@@ -450,6 +468,7 @@ public:
 class epicsShareClass ChannelPutGet : public ChannelRequest {
 public:
     POINTER_DEFINITIONS(ChannelPutGet);
+    typedef ChannelPutGetRequester requester_type;
 
     /**
      * Issue a put/get request. If process was requested when the ChannelPutGet was created this is a put, process, get.
@@ -482,6 +501,7 @@ class epicsShareClass ChannelPutGetRequester : virtual public epics::pvData::Req
 {
 public:
     POINTER_DEFINITIONS(ChannelPutGetRequester);
+    typedef ChannelPutGet operation_type;
 
     /**
      * The client and server have both completed the createChannelPutGet request.
@@ -543,6 +563,7 @@ public:
 class epicsShareClass ChannelRPC : public ChannelRequest {
 public:
     POINTER_DEFINITIONS(ChannelRPC);
+    typedef ChannelRPCRequester requester_type;
 
     /**
      * Issue an RPC request to the channel.
@@ -559,6 +580,7 @@ public:
 class epicsShareClass ChannelRPCRequester : virtual public epics::pvData::Requester {
 public:
     POINTER_DEFINITIONS(ChannelRPCRequester);
+    typedef ChannelRPC operation_type;
 
     /**
      * The client and server have both completed the createChannelGet request.
@@ -613,6 +635,7 @@ class epicsShareClass Channel :
     private epics::pvData::NoDefaultMethods {
 public:
     POINTER_DEFINITIONS(Channel);
+    typedef ChannelRequester requester_type;
 
     virtual ~Channel() {}
 
@@ -789,6 +812,7 @@ public:
 class epicsShareClass ChannelRequester : public virtual epics::pvData::Requester {
 public:
     POINTER_DEFINITIONS(ChannelRequester);
+    typedef Channel operation_type;
 
     /**
      * A channel has been created. This may be called multiple times if there are multiple providers.


### PR DESCRIPTION
Typedefs to link between *Requester classes and associated "operation"s.  eg. ```ChannelGet::requester_type``` is ```ChannelGetRequester``` and ```ChannelGetRequester::operation_type``` is ```ChannelGet```.

ChannelFind/List is an ambiguous.  All others are 1-to-1.  ```ChannelFind::requester_type``` is ```ChannelFind``` while both ```ChannelListRequester::operation_type``` and ```ChannelFindRequester::operation_type``` are ```ChannelFind```.