### PR TITLE
Support for additional Windows targets

### DIFF
--- a/pvtoolsSrc/eget.cpp
+++ b/pvtoolsSrc/eget.cpp
@@ -45,7 +45,7 @@ bool transpose = false;
 
 bool dumpStructure = false;
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(_MINGW)
 FILE *popen(const char *command, const char *mode) {
     return _popen(command, mode);
 }

--- a/pvtoolsSrc/eget.cpp
+++ b/pvtoolsSrc/eget.cpp
@@ -1,4 +1,4 @@
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 

--- a/pvtoolsSrc/pvlist.cpp
+++ b/pvtoolsSrc/pvlist.cpp
@@ -25,7 +25,7 @@
 #include <pv/remote.h>
 #include <pv/rpcClient.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(_MINGW)
 FILE *popen(const char *command, const char *mode) {
     return _popen(command, mode);
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -36,6 +36,9 @@ LIBRARY = pvAccess
 SHRLIB_VERSION = $(EPICS_PVA_MAJOR_VERSION).$(EPICS_PVA_MINOR_VERSION).$(EPICS_PVA_MAINTENANCE_VERSION)
 
 pvAccess_LIBS += pvData
+ifdef WITH_MICROBENCH
+  pvAccess_LIBS += pvMB
+endif
 pvAccess_LIBS += ca
 pvAccess_LIBS += Com
 

--- a/src/ca/caChannel.cpp
+++ b/src/ca/caChannel.cpp
@@ -6,9 +6,10 @@
 
 #include <epicsVersion.h>
 
-#include <pv/logger.h>
 #include <pv/standardField.h>
 
+#define epicsExportSharedSymbols
+#include <pv/logger.h>
 #include <pv/caChannel.h>
 #include <pv/caStatus.h>
 

--- a/src/ca/caProvider.cpp
+++ b/src/ca/caProvider.cpp
@@ -10,10 +10,8 @@
 #include <cadef.h>
 #include <epicsSignal.h>
 
-#include <pv/logger.h>
-
 #define epicsExportSharedSymbols
-
+#include <pv/logger.h>
 #include <pv/caProvider.h>
 #include <pv/caChannel.h>
 

--- a/src/client/pv/pvAccess.h
+++ b/src/client/pv/pvAccess.h
@@ -990,9 +990,9 @@ public:
     virtual std::auto_ptr<stringVector_t> getProviderNames() = 0;
 };
 
-epicsShareExtern ChannelProviderRegistry::shared_pointer getChannelProviderRegistry();
-epicsShareExtern void registerChannelProviderFactory(ChannelProviderFactory::shared_pointer const & channelProviderFactory);
-epicsShareExtern void unregisterChannelProviderFactory(ChannelProviderFactory::shared_pointer const & channelProviderFactory);
+epicsShareFunc ChannelProviderRegistry::shared_pointer getChannelProviderRegistry();
+epicsShareFunc void registerChannelProviderFactory(ChannelProviderFactory::shared_pointer const & channelProviderFactory);
+epicsShareFunc void unregisterChannelProviderFactory(ChannelProviderFactory::shared_pointer const & channelProviderFactory);
 
 
 /**

--- a/src/mb/pv/pvAccessMB.h
+++ b/src/mb/pv/pvAccessMB.h
@@ -1,3 +1,9 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvAccessCPP is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
 #ifndef _PVACCESSMB_H_
 #define _PVACCESSMB_H_
 

--- a/src/mb/pv/pvAccessMB.h
+++ b/src/mb/pv/pvAccessMB.h
@@ -7,11 +7,6 @@
 #ifndef _PVACCESSMB_H_
 #define _PVACCESSMB_H_
 
-#ifdef epicsExportSharedSymbols
-#   define pvAccessMBEpicsExportSharedSymbols
-#   undef epicsExportSharedSymbols
-#endif
-
 #ifdef WITH_MICROBENCH
 
 #include <pv/mb.h>
@@ -42,12 +37,6 @@
 
 #define MB_INIT
 
-#endif
-
-
-#ifdef pvAccessMBEpicsExportSharedSymbols
-#   define epicsExportSharedSymbols
-#	undef pvAccessMBEpicsExportSharedSymbols
 #endif
 
 MB_DECLARE_EXTERN(channelGet);

--- a/src/mb/pvAccessMB.cpp
+++ b/src/mb/pvAccessMB.cpp
@@ -4,6 +4,10 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#include <pv/mb.h>
+
+#define epicsExportSharedSymbols
+
 #include "pv/pvAccessMB.h"
 
 MB_DECLARE(channelGet, 100000);

--- a/src/mb/pvAccessMB.cpp
+++ b/src/mb/pvAccessMB.cpp
@@ -1,3 +1,9 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvAccessCPP is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
 #include "pv/pvAccessMB.h"
 
 MB_DECLARE(channelGet, 100000);

--- a/src/mb/pvAccessMB.cpp
+++ b/src/mb/pvAccessMB.cpp
@@ -4,7 +4,9 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#ifdef WITH_MICROBENCH
 #include <pv/mb.h>
+#endif
 
 #define epicsExportSharedSymbols
 

--- a/src/pipelineService/pv/pipelineServer.h
+++ b/src/pipelineService/pv/pipelineServer.h
@@ -65,7 +65,7 @@ public:
 
 };
 
-epicsShareExtern Channel::shared_pointer createPipelineChannel(ChannelProvider::shared_pointer const & provider,
+epicsShareFunc Channel::shared_pointer createPipelineChannel(ChannelProvider::shared_pointer const & provider,
         std::string const & channelName,
         ChannelRequester::shared_pointer const & channelRequester,
         PipelineService::shared_pointer const & pipelineService);

--- a/src/pva/clientFactory.cpp
+++ b/src/pva/clientFactory.cpp
@@ -4,12 +4,14 @@
  * in file LICENSE that is included with this distribution.
  */
 
-#include <pv/lock.h>
-#include <pv/logger.h>
+#include <string>
 
 #include <epicsSignal.h>
 
+#include <pv/lock.h>
+
 #define epicsExportSharedSymbols
+#include <pv/logger.h>
 #include <pv/clientFactory.h>
 #include <pv/clientContextImpl.h>
 

--- a/src/pva/pv/pvaVersion.h
+++ b/src/pva/pv/pvaVersion.h
@@ -111,7 +111,7 @@ private:
     bool _developmentFlag;
 };
 
-epicsShareExtern std::ostream& operator<<(std::ostream& o, const Version& v);
+epicsShareFunc std::ostream& operator<<(std::ostream& o, const Version& v);
 }
 }
 

--- a/src/remote/abstractResponseHandler.cpp
+++ b/src/remote/abstractResponseHandler.cpp
@@ -4,14 +4,15 @@
  * in file LICENSE that is included with this distribution.
  */
 
-#include <pv/remote.h>
-#include <pv/hexDump.h>
-
-#include <pv/byteBuffer.h>
+#include <sstream>
 
 #include <osiSock.h>
 
-#include <sstream>
+#include <pv/byteBuffer.h>
+
+#define epicsExportSharedSymbols
+#include <pv/remote.h>
+#include <pv/hexDump.h>
 
 using std::ostringstream;
 using std::hex;

--- a/src/remote/beaconHandler.cpp
+++ b/src/remote/beaconHandler.cpp
@@ -4,6 +4,7 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#define epicsExportSharedSymbols
 #include <pv/beaconHandler.h>
 #include <pv/transportRegistry.h>
 

--- a/src/remote/blockingTCPAcceptor.cpp
+++ b/src/remote/blockingTCPAcceptor.cpp
@@ -4,17 +4,18 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#include <sstream>
+
+#include <epicsThread.h>
+#include <osiSock.h>
+
+#include <pv/epicsException.h>
+
+#define epicsExportSharedSymbols
 #include <pv/blockingTCP.h>
 #include <pv/codec.h>
 #include <pv/remote.h>
 #include <pv/logger.h>
-
-#include <pv/epicsException.h>
-
-#include <osiSock.h>
-#include <epicsThread.h>
-
-#include <sstream>
 
 using std::ostringstream;
 using namespace epics::pvData;

--- a/src/remote/blockingTCPConnector.cpp
+++ b/src/remote/blockingTCPConnector.cpp
@@ -4,17 +4,18 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#include <sstream>
+#include <sys/types.h>
+
+#include <osiSock.h>
+#include <epicsThread.h>
+
+#define epicsExportSharedSymbols
 #include <pv/blockingTCP.h>
 #include <pv/remote.h>
 #include <pv/namedLockPattern.h>
 #include <pv/logger.h>
 #include <pv/codec.h>
-
-#include <epicsThread.h>
-#include <osiSock.h>
-
-#include <sys/types.h>
-#include <sstream>
 
 using namespace epics::pvData;
 

--- a/src/remote/blockingUDPConnector.cpp
+++ b/src/remote/blockingUDPConnector.cpp
@@ -4,13 +4,14 @@
  * in file LICENSE that is included with this distribution.
  */
 
-#include <pv/blockingUDP.h>
-#include <pv/remote.h>
-#include <pv/logger.h>
+#include <sys/types.h>
 
 #include <osiSock.h>
 
-#include <sys/types.h>
+#define epicsExportSharedSymbols
+#include <pv/blockingUDP.h>
+#include <pv/remote.h>
+#include <pv/logger.h>
 
 using namespace std;
 using namespace epics::pvData;

--- a/src/remote/blockingUDPTransport.cpp
+++ b/src/remote/blockingUDPTransport.cpp
@@ -9,21 +9,22 @@
 #include <ws2tcpip.h>
 #endif
 
+#include <sys/types.h>
+#include <cstdio>
+
+#include <epicsThread.h>
+#include <osiSock.h>
+#include <osdSock.h>
+
+#include <pv/lock.h>
+#include <pv/byteBuffer.h>
+
+#define epicsExportSharedSymbols
 #include <pv/blockingUDP.h>
 #include <pv/pvaConstants.h>
 #include <pv/inetAddressUtil.h>
 #include <pv/logger.h>
 #include <pv/likely.h>
-
-#include <pv/byteBuffer.h>
-#include <pv/lock.h>
-
-#include <osdSock.h>
-#include <osiSock.h>
-#include <epicsThread.h>
-
-#include <cstdio>
-#include <sys/types.h>
 
 using namespace epics::pvData;
 using namespace std;

--- a/src/remote/codec.cpp
+++ b/src/remote/codec.cpp
@@ -8,23 +8,33 @@
 #endif
 
 
-#include <epicsThread.h>
-#include <osiSock.h>
-
-#include <sys/types.h>
-#include <sstream>
-#include <stdexcept>
-#include <limits>
-#include <vector>
-#include <string>
 #include <map>
+#include <string>
+#include <vector>
+#include <limits>
+#include <stdexcept>
+#include <sstream>
+#include <sys/types.h>
+
+#include <osiSock.h>
+#include <epicsTime.h>
+#include <epicsThread.h>
+#include <epicsVersion.h>
+
+#include <pv/byteBuffer.h>
+#include <pv/pvType.h>
+#include <pv/lock.h>
+#include <pv/timer.h>
+#include <pv/event.h>
 
 #define epicsExportSharedSymbols
 #include <pv/blockingTCP.h>
 #include <pv/remote.h>
+#include <pv/inetAddressUtil.h>
 #include <pv/namedLockPattern.h>
 #include <pv/hexDump.h>
 #include <pv/logger.h>
+#include <pv/likely.h>
 #include <pv/codec.h>
 #include <pv/serializationHelper.h>
 

--- a/src/remote/codec.cpp
+++ b/src/remote/codec.cpp
@@ -3,7 +3,8 @@
 * pvAccessCPP is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 */
-#ifdef _WIN32
+
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 

--- a/src/remote/pv/blockingUDP.h
+++ b/src/remote/pv/blockingUDP.h
@@ -505,7 +505,7 @@ private:
 
 typedef std::vector<BlockingUDPTransport::shared_pointer> BlockingUDPTransportVector;
 
-epicsShareExtern void initializeUDPTransports(
+epicsShareFunc void initializeUDPTransports(
     bool serverFlag,
     BlockingUDPTransportVector& udpTransports,
     const IfaceNodeVector& ifaceList,

--- a/src/remote/pv/channelSearchManager.h
+++ b/src/remote/pv/channelSearchManager.h
@@ -14,12 +14,12 @@
 
 #include <osiSock.h>
 
-#include <pv/remote.h>
-
 #ifdef channelSearchManagerEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
 #	undef channelSearchManagerEpicsExportSharedSymbols
 #endif
+
+#include <pv/remote.h>
 
 namespace epics {
 namespace pvAccess {

--- a/src/remote/pv/codec.h
+++ b/src/remote/pv/codec.h
@@ -11,13 +11,7 @@
 #include <map>
 #include <deque>
 
-#ifdef epicsExportSharedSymbols
-#   define abstractCodecEpicsExportSharedSymbols
-#   undef epicsExportSharedSymbols
-#endif
-
 #include <shareLib.h>
-#include <osdSock.h>
 #include <osiSock.h>
 #include <epicsTime.h>
 #include <epicsThread.h>
@@ -37,11 +31,6 @@
 #include <pv/event.h>
 #include <pv/likely.h>
 
-#ifdef abstractCodecEpicsExportSharedSymbols
-#   define epicsExportSharedSymbols
-#	undef abstractCodecEpicsExportSharedSymbols
-#endif
-
 #include <pv/pvaConstants.h>
 #include <pv/remote.h>
 #include <pv/security.h>
@@ -50,7 +39,6 @@
 #include <pv/namedLockPattern.h>
 #include <pv/inetAddressUtil.h>
 
-#include <shareLib.h>
 
 namespace epics {
 namespace pvAccess {

--- a/src/remote/pv/serializationHelper.h
+++ b/src/remote/pv/serializationHelper.h
@@ -8,21 +8,11 @@
 #ifndef SERIALIZATIONHELPER_H_
 #define SERIALIZATIONHELPER_H_
 
-#ifdef epicsExportSharedSymbols
-#   define serializationHelperEpicsExportSharedSymbols
-#   undef epicsExportSharedSymbols
-#endif
-
 #include <pv/serialize.h>
 #include <pv/pvData.h>
 #include <pv/noDefaultMethods.h>
 #include <pv/pvIntrospect.h>
 #include <pv/byteBuffer.h>
-
-#ifdef serializationHelperEpicsExportSharedSymbols
-#   define epicsExportSharedSymbols
-#	undef serializationHelperEpicsExportSharedSymbols
-#endif
 
 #include <pv/pvaConstants.h>
 #include <pv/pvAccess.h>

--- a/src/remote/pv/transportRegistry.h
+++ b/src/remote/pv/transportRegistry.h
@@ -21,14 +21,15 @@
 #include <pv/lock.h>
 #include <pv/pvType.h>
 #include <pv/epicsException.h>
-#include <pv/remote.h>
-#include <pv/inetAddressUtil.h>
 #include <pv/sharedPtr.h>
 
 #ifdef transportRegistryEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
 #	undef transportRegistryEpicsExportSharedSymbols
 #endif
+
+#include <pv/remote.h>
+#include <pv/inetAddressUtil.h>
 
 namespace epics {
 namespace pvAccess {

--- a/src/remote/serializationHelper.cpp
+++ b/src/remote/serializationHelper.cpp
@@ -4,6 +4,12 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#include <pv/serialize.h>
+#include <pv/pvData.h>
+#include <pv/noDefaultMethods.h>
+#include <pv/pvIntrospect.h>
+#include <pv/byteBuffer.h>
+
 #define epicsExportSharedSymbols
 #include <pv/serializationHelper.h>
 #include <pv/introspectionRegistry.h>

--- a/src/remote/simpleChannelSearchManagerImpl.cpp
+++ b/src/remote/simpleChannelSearchManagerImpl.cpp
@@ -4,15 +4,17 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#include <stdlib.h>
+#include <time.h>
+#include <vector>
+
+#include <pv/timeStamp.h>
+
+#define epicsExportSharedSymbols
 #include <pv/simpleChannelSearchManagerImpl.h>
 #include <pv/pvaConstants.h>
 #include <pv/blockingUDP.h>
 #include <pv/serializeHelper.h>
-
-#include <stdlib.h>
-#include <time.h>
-#include <pv/timeStamp.h>
-#include <vector>
 
 using namespace std;
 using namespace epics::pvData;

--- a/src/remote/transportRegistry.cpp
+++ b/src/remote/transportRegistry.cpp
@@ -4,6 +4,7 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#define epicsExportSharedSymbols
 #include <pv/transportRegistry.h>
 
 using namespace epics::pvData;

--- a/src/remoteClient/clientContextImpl.cpp
+++ b/src/remoteClient/clientContextImpl.cpp
@@ -13,10 +13,10 @@
 #include <pv/lock.h>
 #include <pv/timer.h>
 #include <pv/bitSetUtil.h>
-#include <pv/serializationHelper.h>
 #include <pv/queue.h>
 #include <pv/standardPVField.h>
 
+#define epicsExportSharedSymbols
 #include <pv/pvAccess.h>
 #include <pv/pvaConstants.h>
 #include <pv/blockingUDP.h>
@@ -26,6 +26,7 @@
 #include <pv/hexDump.h>
 #include <pv/remote.h>
 #include <pv/channelSearchManager.h>
+#include <pv/serializationHelper.h>
 #include <pv/simpleChannelSearchManagerImpl.h>
 #include <pv/clientContextImpl.h>
 #include <pv/configuration.h>

--- a/src/remoteClient/pv/clientContextImpl.h
+++ b/src/remoteClient/pv/clientContextImpl.h
@@ -131,7 +131,7 @@ public:
     virtual void destroy() = 0;
 };
 
-epicsShareExtern ChannelProvider::shared_pointer createClientProvider(const Configuration::shared_pointer& conf);
+epicsShareFunc ChannelProvider::shared_pointer createClientProvider(const Configuration::shared_pointer& conf);
 
 }
 }

--- a/src/rpcService/pv/rpcServer.h
+++ b/src/rpcService/pv/rpcServer.h
@@ -67,7 +67,7 @@ public:
 
 };
 
-epicsShareExtern Channel::shared_pointer createRPCChannel(ChannelProvider::shared_pointer const & provider,
+epicsShareFunc Channel::shared_pointer createRPCChannel(ChannelProvider::shared_pointer const & provider,
         std::string const & channelName,
         ChannelRequester::shared_pointer const & channelRequester,
         Service::shared_pointer const & rpcService);

--- a/src/server/baseChannelRequester.cpp
+++ b/src/server/baseChannelRequester.cpp
@@ -4,6 +4,7 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#define epicsExportSharedSymbols
 #include <pv/baseChannelRequester.h>
 
 using namespace epics::pvData;

--- a/src/server/beaconEmitter.cpp
+++ b/src/server/beaconEmitter.cpp
@@ -4,7 +4,7 @@
  * in file LICENSE that is included with this distribution.
  */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 

--- a/src/server/beaconEmitter.cpp
+++ b/src/server/beaconEmitter.cpp
@@ -8,12 +8,12 @@
 #define NOMINMAX
 #endif
 
-#include <pv/beaconEmitter.h>
-#include <pv/serializationHelper.h>
-
-#include <pv/logger.h>
 #include <algorithm>
 
+#define epicsExportSharedSymbols
+#include <pv/beaconEmitter.h>
+#include <pv/serializationHelper.h>
+#include <pv/logger.h>
 #include <pv/serverContext.h>
 
 using namespace std;

--- a/src/server/pv/responseHandlers.h
+++ b/src/server/pv/responseHandlers.h
@@ -7,17 +7,7 @@
 #ifndef RESPONSEHANDLERS_H_
 #define RESPONSEHANDLERS_H_
 
-#ifdef epicsExportSharedSymbols
-#   define responseHandlersEpicsExportSharedSymbols
-#   undef epicsExportSharedSymbols
-#endif
-
 #include <pv/timer.h>
-
-#ifdef responseHandlersEpicsExportSharedSymbols
-#   define epicsExportSharedSymbols
-#	undef responseHandlersEpicsExportSharedSymbols
-#endif
 
 #include <pv/serverContext.h>
 #include <pv/remote.h>

--- a/src/server/pv/serverContext.h
+++ b/src/server/pv/serverContext.h
@@ -453,7 +453,7 @@ private:
 
 };
 
-epicsShareExtern ServerContext::shared_pointer startPVAServer(
+epicsShareFunc ServerContext::shared_pointer startPVAServer(
     std::string const & providerNames = PVACCESS_ALL_PROVIDERS,
     int timeToRun = 0,
     bool runInSeparateThread = false,

--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -17,17 +17,18 @@
 #include <time.h>
 #include <stdlib.h>
 
+#include <osiSock.h>
+#include <osiProcess.h>
+
+#include <pv/byteBuffer.h>
+#include <pv/timer.h>
+
+#define epicsExportSharedSymbols
 #include <pv/responseHandlers.h>
 #include <pv/remote.h>
 #include <pv/hexDump.h>
 #include <pv/serializationHelper.h>
-
-#include <pv/byteBuffer.h>
-
-#include <osiSock.h>
-#include <osiProcess.h>
 #include <pv/logger.h>
-
 #include <pv/pvAccessMB.h>
 #include <pv/rpcServer.h>
 #include <pv/security.h>

--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -4,18 +4,26 @@
  * in file LICENSE that is included with this distribution.
  */
 
-#ifdef __vxworks
-#include <taskLib.h>
-#endif
-
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
-#include <process.h>
 #endif
 
 #include <sstream>
 #include <time.h>
 #include <stdlib.h>
+
+#ifdef _WIN32
+#define GETPID() GetCurrentProcessId()
+#endif
+
+#ifdef vxWorks
+#include <taskLib.h>
+#define GETPID() taskIdSelf()
+#endif
+
+#ifndef GETPID
+#define GETPID() getpid()
+#endif
 
 #include <osiSock.h>
 #include <osiProcess.h>
@@ -619,13 +627,7 @@ public:
             result->getSubFieldT<PVString>("host")->put(hostName);
 
             std::stringstream sspid;
-#ifdef __vxworks
-            sspid << taskIdSelf();
-#elif defined(_WIN32)
-            sspid << _getpid();
-#else
-            sspid << getpid();
-#endif
+            sspid << GETPID();
             result->getSubFieldT<PVString>("process")->put(sspid.str());
 
             char timeText[64];

--- a/src/server/serverChannelImpl.cpp
+++ b/src/server/serverChannelImpl.cpp
@@ -4,6 +4,7 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#define epicsExportSharedSymbols
 #include <pv/serverChannelImpl.h>
 
 using namespace epics::pvData;

--- a/src/server/serverContext.cpp
+++ b/src/server/serverContext.cpp
@@ -6,6 +6,10 @@
 
 #include <epicsSignal.h>
 
+#include <pv/lock.h>
+#include <pv/timer.h>
+#include <pv/thread.h>
+
 #define epicsExportSharedSymbols
 #include <pv/responseHandlers.h>
 #include <pv/logger.h>

--- a/src/utils/inetAddressUtil.cpp
+++ b/src/utils/inetAddressUtil.cpp
@@ -9,10 +9,12 @@
 #include <cstdlib>
 #include <sstream>
 
-#include <pv/byteBuffer.h>
-#include <pv/epicsException.h>
 #include <osiSock.h>
 #include <ellLib.h>
+
+#include <pv/pvType.h>
+#include <pv/byteBuffer.h>
+#include <pv/epicsException.h>
 
 #define epicsExportSharedSymbols
 #include <pv/inetAddressUtil.h>

--- a/src/utils/introspectionRegistry.cpp
+++ b/src/utils/introspectionRegistry.cpp
@@ -4,6 +4,7 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#define epicsExportSharedSymbols
 #include <pv/introspectionRegistry.h>
 #include <pv/serializationHelper.h>
 

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -10,14 +10,13 @@
 #include <cstring>
 #include <stdio.h>
 
+#include <epicsExit.h>
+#include <errlog.h>
+#include <epicsTime.h>
+
 #include <pv/noDefaultMethods.h>
 #include <pv/lock.h>
 #include <pv/pvType.h>
-
-#include <epicsExit.h>
-#include <errlog.h>
-
-#include <epicsTime.h>
 
 #define epicsExportSharedSymbols
 #include <pv/logger.h>

--- a/src/utils/pv/inetAddressUtil.h
+++ b/src/utils/pv/inetAddressUtil.h
@@ -9,22 +9,11 @@
 
 #include <vector>
 
-#ifdef epicsExportSharedSymbols
-#   define inetAddressUtilExportSharedSymbols
-#   undef epicsExportSharedSymbols
-#endif
+#include <osiSock.h>
+#include <shareLib.h>
 
 #include <pv/pvType.h>
 #include <pv/byteBuffer.h>
-
-#include <osiSock.h>
-
-#ifdef inetAddressUtilExportSharedSymbols
-#   define epicsExportSharedSymbols
-#   undef inetAddressUtilExportSharedSymbols
-#endif
-
-#include <shareLib.h>
 
 
 // TODO implement using smart pointers

--- a/src/utils/pv/logger.h
+++ b/src/utils/pv/logger.h
@@ -48,9 +48,9 @@ OFF
 */
 
 
-epicsShareExtern void pvAccessLog(pvAccessLogLevel level, const char* format, ...);
-epicsShareExtern void pvAccessSetLogLevel(pvAccessLogLevel level);
-epicsShareExtern bool pvAccessIsLoggable(pvAccessLogLevel level);
+epicsShareFunc void pvAccessLog(pvAccessLogLevel level, const char* format, ...);
+epicsShareFunc void pvAccessSetLogLevel(pvAccessLogLevel level);
+epicsShareFunc bool pvAccessIsLoggable(pvAccessLogLevel level);
 
 #if defined (__GNUC__) && __GNUC__ < 3
 #define LOG(level, format, ARGS...) pvAccessLog(level, format, ##ARGS)
@@ -76,7 +76,7 @@ epicsShareExtern bool pvAccessIsLoggable(pvAccessLogLevel level);
     * @param[in] fname The file to write to. If the file exists, it
     * is opened for append.
     */
-epicsShareExtern void createFileLogger( std::string const & fname );
+epicsShareFunc void createFileLogger( std::string const & fname );
 
 }
 }

--- a/src/utils/pv/logger.h
+++ b/src/utils/pv/logger.h
@@ -7,18 +7,7 @@
 #ifndef LOGGER_H_
 #define LOGGER_H_
 
-#ifdef epicsExportSharedSymbols
-#   define loggerEpicsExportSharedSymbols
-#   undef epicsExportSharedSymbols
-#endif
-
-#include <pv/pvType.h>
-#include <errlog.h>
-
-#ifdef loggerEpicsExportSharedSymbols
-#   define epicsExportSharedSymbols
-#undef loggerEpicsExportSharedSymbols
-#endif
+#include <string>
 
 #include <shareLib.h>
 

--- a/src/utils/referenceCountingLock.cpp
+++ b/src/utils/referenceCountingLock.cpp
@@ -4,6 +4,7 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#define epicsExportSharedSymbols
 #include <pv/referenceCountingLock.h>
 
 namespace epics {

--- a/testApp/remote/channelAccessIFTest.cpp
+++ b/testApp/remote/channelAccessIFTest.cpp
@@ -1987,7 +1987,7 @@ void ChannelAccessIFTest::test_channelArray() {
     PVDoubleArrayPtr array3 = TR1::static_pointer_cast<PVDoubleArray>(arrayReq->getArray());
     PVDoubleArray::const_svector data3(array3->view());
     testOk(data3.size() == newLength,
-           "%s: data size after calling setLength should be %zu", CURRENT_FUNCTION, newLength);
+           "%s: data size after calling setLength should be %lu", CURRENT_FUNCTION, (unsigned long) newLength);
     testOk(data3[0] == 1.1 , "%s: 3.check 0: %f", CURRENT_FUNCTION, data3[0]);
     testOk(data3[1] == 2.2 , "%s: 3.check 1: %f", CURRENT_FUNCTION, data3[1]);
 
@@ -2007,8 +2007,8 @@ void ChannelAccessIFTest::test_channelArray() {
 
     PVDoubleArrayPtr array4 = TR1::static_pointer_cast<PVDoubleArray>(arrayReq->getArray());
     PVDoubleArray::const_svector data4(array4->view());
-    testOk(data4.size() == bigCapacity, "%s: data size after calling setLength should be %zu",
-           CURRENT_FUNCTION, bigCapacity);
+    testOk(data4.size() == bigCapacity, "%s: data size after calling setLength should be %lu",
+           CURRENT_FUNCTION, (unsigned long) bigCapacity);
     testOk(data4[0] == 1.1 , "%s: 4.check 0: %f", CURRENT_FUNCTION, data4[0]);
     testOk(data4[1] == 2.2 , "%s: 4.check 1: %f", CURRENT_FUNCTION, data4[1]);
     /*
@@ -2022,7 +2022,7 @@ void ChannelAccessIFTest::test_channelArray() {
       if (i == bigCapacity)
         testOk("%s: 4.check: all data 0.0", CURRENT_FUNCTION);
       else
-        testFail("%s: 4.check: data at %zu should be 0.0 but was %f", CURRENT_FUNCTION, i, data4[i]);
+        testFail("%s: 4.check: data at %lu should be 0.0 but was %f", CURRENT_FUNCTION, (unsigned long) i, data4[i]);
     }
     else {
       testFail("%s: will not check the rest of the array if the size is not correct", CURRENT_FUNCTION);
@@ -2040,7 +2040,7 @@ void ChannelAccessIFTest::test_channelArray() {
         testFail("%s: an array getLength failed", CURRENT_FUNCTION);
         return;
     }
-    testOk(arrayReq->getLength() == newLen, "%s: retrieved length should be %zu", CURRENT_FUNCTION, newLen);
+    testOk(arrayReq->getLength() == newLen, "%s: retrieved length should be %lu", CURRENT_FUNCTION, (unsigned long) newLen);
 
 
     channel->destroy();
@@ -2180,7 +2180,7 @@ void ChannelAccessIFTest::test_stressPutAndGetLargeArray() {
 
     for (size_t len = minSize; len <= maxSize; len+=step) {
 
-        //testDiag("%s: array size %zd", CURRENT_FUNCTION, len);
+        //testDiag("%s: array size %lu", CURRENT_FUNCTION, (unsigned long) len);
 
         // prepare data
         newdata.resize(len);
@@ -2192,19 +2192,19 @@ void ChannelAccessIFTest::test_stressPutAndGetLargeArray() {
 
         bool succStatus = putReq->syncPut(false, getTimeoutSec());
         if (!succStatus) {
-            testFail("%s: sync put failed at array size %zd", CURRENT_FUNCTION, len);
+            testFail("%s: sync put failed at array size %lu", CURRENT_FUNCTION, (unsigned long) len);
             return;
         }
 
         succStatus = putReq->syncGet(getTimeoutSec());
         if (!succStatus) {
-            testFail("%s: sync get failed at array size %zd", CURRENT_FUNCTION, len);
+            testFail("%s: sync get failed at array size %lu", CURRENT_FUNCTION, (unsigned long) len);
             return;
         }
 
         // length check
         if (value->getLength() != len) {
-            testFail("%s: length does not math %zd != %zd", CURRENT_FUNCTION, len, value->getLength());
+            testFail("%s: length does not match %lu != %lu", CURRENT_FUNCTION, (unsigned long) len, (unsigned long) value->getLength());
             return;
         }
 
@@ -2212,7 +2212,7 @@ void ChannelAccessIFTest::test_stressPutAndGetLargeArray() {
         PVDoubleArray::const_svector data(value->view());
         for (size_t i = 0; i < len; i++) {
             if (i != data[i])        // NOTE: floating-point value comparison without delta
-                testFail("%s: data slot %zd does not match %f != %f at array size %zd", CURRENT_FUNCTION, i, (double)i, data[i], len);
+                testFail("%s: data slot %lu does not match %f != %f at array size %lu", CURRENT_FUNCTION, (unsigned long) i, (double)i, data[i], (unsigned long) len);
         }
 
     }

--- a/testApp/remote/testCodec.cpp
+++ b/testApp/remote/testCodec.cpp
@@ -2,7 +2,7 @@
 * testCodec.cpp
 */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 

--- a/testApp/remote/testGetPerformance.cpp
+++ b/testApp/remote/testGetPerformance.cpp
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 
 #ifdef _WIN32
-#include <WinSock2.h>
+#include <winsock2.h>
 #else
 #include <sys/time.h>
 #endif

--- a/testApp/remote/testMonitorPerformance.cpp
+++ b/testApp/remote/testMonitorPerformance.cpp
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 
 #ifdef _WIN32
-#include <WinSock2.h>
+#include <winsock2.h>
 #else
 #include <sys/time.h>
 #endif

--- a/testApp/remote/testServer.cpp
+++ b/testApp/remote/testServer.cpp
@@ -2,7 +2,7 @@
  * testServer.cpp
  */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 

--- a/testApp/utils/testInetAddressUtils.cpp
+++ b/testApp/utils/testInetAddressUtils.cpp
@@ -217,7 +217,7 @@ void test_getLoopbackNIF()
 
 #ifdef _WIN32
 // needed for ip_mreq
-#include <Ws2tcpip.h>
+#include <ws2tcpip.h>
 #endif
 
 void test_multicastLoopback()


### PR DESCRIPTION
These changes allow pvAccessCPP to be built for the Cygwin and MinGW targets, including cross-compiling for MinGW on Linux. A few other minor cleanups are included as well.