### PR TITLE
Test assumptions about ChannelProvider ownership

### DIFF
--- a/testApp/remote/Makefile
+++ b/testApp/remote/Makefile
@@ -12,6 +12,9 @@ testCodec_SRCS = testCodec
 testHarness_SRCS += testCodec.cpp
 TESTS += testCodec
 
+TESTPROD_HOST += testProviders
+testProviders_SRCS += testProviders.cpp
+TESTS += testProviders
 
 TESTPROD_HOST += testRemoteClientImpl
 testRemoteClientImpl_SRCS += testRemoteClientImpl.cpp
@@ -21,7 +24,6 @@ testChannelConnect_SRCS += testChannelConnect.cpp
 
 TESTPROD_HOST += testServerContext
 testServerContext_SRCS += testServerContext.cpp
-
 
 
 PROD_HOST += testServer

--- a/testApp/remote/testProviders.cpp
+++ b/testApp/remote/testProviders.cpp
@@ -1,0 +1,209 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * pvAccessCPP is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+
+#include <epicsUnitTest.h>
+#include <testMain.h>
+#include <epicsThread.h>
+
+#include <pv/pvAccess.h>
+#include <pv/clientFactory.h>
+#include <pv/caProvider.h>
+
+namespace {
+
+namespace pvd = epics::pvData;
+namespace pva = epics::pvAccess;
+
+struct TestChanReq : public pva::ChannelRequester
+{
+    POINTER_DEFINITIONS(TestChanReq);
+
+    virtual std::string getRequesterName() { return "TestChanReq"; }
+
+    virtual void channelCreated(const pvd::Status& status, pva::Channel::shared_pointer const & channel)
+    {}
+
+    virtual void channelStateChange(pva::Channel::shared_pointer const & channel, pva::Channel::ConnectionState connectionState)
+    {}
+};
+
+struct TestGetReq : public pva::ChannelGetRequester
+{
+    POINTER_DEFINITIONS(TestGetReq);
+
+    virtual std::string getRequesterName() { return "TestGetReq"; }
+
+    virtual void channelGetConnect(
+        const pvd::Status& status,
+        pva::ChannelGet::shared_pointer const & channelGet,
+        pvd::Structure::const_shared_pointer const & structure)
+    {}
+
+    virtual void getDone(
+        const pvd::Status& status,
+        pva::ChannelGet::shared_pointer const & channelGet,
+        pvd::PVStructure::shared_pointer const & pvStructure,
+        pvd::BitSet::shared_pointer const & bitSet)
+    {}
+};
+
+static
+void testChannelCreateDestroy(const char *providerName,
+                              const char *badChannel)
+{
+    testDiag("testChannelCreateDestroy(\"%s\", \"%s\")", providerName, badChannel);
+
+    pva::ChannelProvider::shared_pointer provider(pva::getChannelProviderRegistry()->createProvider(providerName));
+    pva::ChannelProvider::weak_pointer providerW(provider);
+
+    testOk(provider.unique(), "create provider refs=%u", (unsigned)provider.use_count());
+
+    TestChanReq::shared_pointer req(new TestChanReq);
+    pva::Channel::shared_pointer chan(provider->createChannel(badChannel, req));
+    pva::Channel::weak_pointer chanW(chan);
+
+    testOk(chan.unique(), "create non-existant channel refs=%u", (unsigned)chan.use_count());
+    epicsThreadSleep(1.0); // wait in case some worker thread is lazy...
+    testOk(chan.unique(), "2create non-existant channel refs=%u", (unsigned)chan.use_count());
+
+    chan->destroy();
+
+    testOk(chan.unique(), "destroy non-existant channel refs=%u", (unsigned)chan.use_count());
+    testOk(req.unique(), "ChannelRequester after Channel::destroy() refs=%u", (unsigned)req.use_count());
+    epicsThreadSleep(1.0);
+    testOk(chan.unique(), "2destroy non-existant channel refs=%u", (unsigned)chan.use_count());
+    testOk(req.unique(), "2ChannelRequester after Channel::destroy() refs=%u", (unsigned)req.use_count());
+
+    chan.reset();
+    testOk(req.unique(), "ChannelRequester after Channel last refs=%u", (unsigned)req.use_count());
+    req.reset();
+
+    testOk(!chanW.lock(), "Channel leaked from live Provider");
+
+    testOk(provider.unique(), "empty provider refs=%u", (unsigned)provider.use_count());
+    epicsThreadSleep(1.0);
+    testOk(provider.unique(), "2empty provider refs=%u", (unsigned)provider.use_count());
+
+    provider->destroy();
+
+    testOk(provider.unique(), "empty provider refs=%u", (unsigned)provider.use_count());
+    epicsThreadSleep(1.0);
+    testOk(provider.unique(), "2empty provider refs=%u", (unsigned)provider.use_count());
+
+    testOk(!chanW.lock(), "Channel leaked from dead Provider");
+
+    provider.reset();
+
+    testOk(!providerW.lock(), "Provider leaks");
+}
+
+static
+void testChannelCreateDrop(const char *providerName,
+                              const char *badChannel)
+{
+    testDiag("testChannelCreateDrop(\"%s\", \"%s\")", providerName, badChannel);
+
+    pva::ChannelProvider::shared_pointer provider(pva::getChannelProviderRegistry()->createProvider(providerName));
+    pva::ChannelProvider::weak_pointer providerW(provider);
+
+    testOk(provider.unique(), "create provider refs=%u", (unsigned)provider.use_count());
+
+    TestChanReq::shared_pointer req(new TestChanReq);
+    pva::Channel::shared_pointer chan(provider->createChannel(badChannel, req));
+    pva::Channel::weak_pointer chanW(chan);
+
+    testOk(chan.unique(), "create non-existant channel refs=%u", (unsigned)chan.use_count());
+    epicsThreadSleep(1.0);
+    testOk(chan.unique(), "2create non-existant channel refs=%u", (unsigned)chan.use_count());
+
+    testDiag("Drop our ref to Channel w/o destory()");
+
+    chan.reset();
+    testOk(req.unique(), "ChannelRequester after Channel last refs=%u", (unsigned)req.use_count());
+    req.reset();
+
+    testOk(!chanW.lock(), "Channel leaked from live Provider");
+
+    testOk(provider.unique(), "empty provider refs=%u", (unsigned)provider.use_count());
+    epicsThreadSleep(1.0);
+    testOk(provider.unique(), "2empty provider refs=%u", (unsigned)provider.use_count());
+
+    provider->destroy();
+
+    testOk(provider.unique(), "empty provider refs=%u", (unsigned)provider.use_count());
+    epicsThreadSleep(1.0);
+    testOk(provider.unique(), "2empty provider refs=%u", (unsigned)provider.use_count());
+
+    testOk(!chanW.lock(), "Channel leaked from dead Provider");
+
+    provider.reset();
+
+    testOk(!providerW.lock(), "Provider leaks");
+}
+
+static
+void testChannelGet(const char *providerName,
+                    const char *badChannel)
+{
+    testDiag("testChannelGet(\"%s\", \"%s\")", providerName, badChannel);
+
+    pva::ChannelProvider::shared_pointer provider(pva::getChannelProviderRegistry()->createProvider(providerName));
+
+    testOk(provider.unique(), "create provider refs=%u", (unsigned)provider.use_count());
+
+    TestChanReq::shared_pointer req(new TestChanReq);
+    pva::Channel::shared_pointer chan(provider->createChannel(badChannel, req));
+
+    testOk(chan.unique(), "create non-existant channel refs=%u", (unsigned)chan.use_count());
+
+    TestGetReq::shared_pointer getreq(new TestGetReq);
+    pva::ChannelGet::shared_pointer get(chan->createChannelGet(getreq,
+                                                               pvd::getPVDataCreate()->createPVStructure(
+                                                                   pvd::getFieldCreate()->createFieldBuilder()->createStructure()
+                                                                   )));
+
+    testOk(get.unique(), "create get refs=%u", (unsigned)get.use_count());
+
+    get->destroy();
+
+    testOk(get.unique(), "get after ChannelGet::destroy() refs=%u", (unsigned)get.use_count());
+    testOk(getreq.unique(), "getreq after ChannelGet::destroy() refs=%u", (unsigned)getreq.use_count());
+
+    chan->destroy();
+
+    testOk(chan.unique(), "destroy non-existant channel refs=%u", (unsigned)chan.use_count());
+    testOk(req.unique(), "ChannelRequester after Channel::destroy() refs=%u", (unsigned)req.use_count());
+
+    get.reset();
+    getreq.reset();
+    chan.reset();
+    req.reset();
+
+    testOk(provider.unique(), "empty provider refs=%u", (unsigned)provider.use_count());
+}
+
+} // namespace
+
+MAIN(testProviders) {
+    testPlan(0);
+    testDiag("==== PVA ====");
+    {
+        pva::ClientFactory::start();
+        testChannelCreateDestroy("pva", "reallyInvalidChannelName");
+        testChannelCreateDrop   ("pva", "reallyInvalidChannelName");
+        testChannelGet          ("pva", "reallyInvalidChannelName");
+        pva::ClientFactory::stop();
+    }
+    testDiag("==== CA ====");
+    {
+        pva::ca::CAClientFactory::start();
+        testChannelCreateDestroy("ca", "reallyInvalidChannelName");
+        testChannelCreateDrop   ("ca", "reallyInvalidChannelName");
+        testChannelGet          ("ca", "reallyInvalidChannelName");
+        pva::ca::CAClientFactory::stop();
+    }
+    return testDone();
+}


### PR DESCRIPTION
Add testProvider unittest as a work in progress to document/tests my assumptions about the ownership of Channel and ChannelGet returned by the PVA and CA client providers.  What I see is that complete shutdown (eg. destroy() provider) does cleanup everything, but that variations on partial shutdown don't seem to.  At least in the ways I'm expecting.

I know that some of these tests should fail now.  This will hopefully change during this discussion.

Specifically, I expect that:

1. Calling ```->destroy()``` on Channel/ChannelGet/... should (immediately?) release references to the corresponding ```Requester```.

2. Calling ```->destroy()``` on Channel/ChannelGet/... should (eventually?) release all internal references.

3. While a ```Channel``` may be shared implicitly, a ```ChannelGet``` or similar operation accepting a pvRequest is exclusively owned by the caller of ```createChannelGet()```.

4. Calling ```->destroy()``` on Channel will implicitly destroy all operations (Channel*).

5. Orphaned Channel instance (no external references) will eventually be closed?

Are these expectations correct?  Apparent violation of 1 by ChannelGet w/ PVA is causing me trouble.
