### PR TITLE
Rework ChannelProviderRegistry

### DIFF
--- a/testApp/remote/testServerContext.cpp
+++ b/testApp/remote/testServerContext.cpp
@@ -17,6 +17,7 @@ public:
         return "local";
     };
 
+    TestChannelProvider(const std::tr1::shared_ptr<Configuration>&) {}
 
     ChannelFind::shared_pointer channelFind(std::string const & /*channelName*/,
                                             ChannelFindRequester::shared_pointer const & channelFindRequester)
@@ -57,41 +58,12 @@ public:
     }
 };
 
-
-class TestChannelProviderRegistry : public ChannelProviderRegistry {
-public:
-
-    virtual ~TestChannelProviderRegistry() {};
-
-    ChannelProvider::shared_pointer getProvider(std::string const & providerName)
-    {
-        if (providerName == "local")
-        {
-            return ChannelProvider::shared_pointer(new TestChannelProvider());
-        }
-        else
-            return ChannelProvider::shared_pointer();
-    }
-
-    ChannelProvider::shared_pointer createProvider(std::string const & providerName)
-    {
-        return getProvider(providerName);
-    }
-
-    std::auto_ptr<stringVector_t> getProviderNames()
-    {
-        std::auto_ptr<stringVector_t> pn(new stringVector_t());
-        pn->push_back("local");
-        return pn;
-    }
-};
-
 void testServerContext()
 {
-
     ServerContextImpl::shared_pointer ctx = ServerContextImpl::create();
 
-    ChannelProviderRegistry::shared_pointer ca(new TestChannelProviderRegistry());
+    ChannelProviderRegistry::shared_pointer ca(ChannelProviderRegistry::build());
+    ca->add<TestChannelProvider>("local");
     ctx->initialize(ca);
 
     ctx->printInfo();


### PR DESCRIPTION
Replace interface+impls with a single concrete container which wraps a map.

This breaks code which was sub-classing.  However, I can find no external code which does this.

A build() method is used instead of simple ctor so that the ctor is private, which will cause theoretical external sub-class code to fail to compile.

Code using getChannelProviderRegistry() and existing methods will behave as before.

Add ChannelProviderRegistry::getFactory() for pass through to ChannelProviderFactory (Registery is just a proxy()...)

Add newInstance() overload which accepts a specific Configuration.  This allows code (eg. unit tests) to get specially configured Providers.

Add SimpleChannelProviderFactory to cut down on boilerplate for the common case.

Add method to clear mapping and release any saved sharedInstance.