### PR TITLE
When caProvider is destroyed make sure all channels are cleared

### DIFF
--- a/src/ca/caChannel.cpp
+++ b/src/ca/caChannel.cpp
@@ -422,13 +422,10 @@ void CAChannel::disconnectChannel()
              << " channelCreated " << (channelCreated ? "true" : "false")
              << endl;
     }
-    bool disconnect = true;
     {
         Lock lock(requestsMutex);
-        if(!channelCreated) disconnect = false;
-        channelCreated = false;
+        if(!channelCreated) return;
     }
-    if(!disconnect) return;
     /* Clear CA Channel */
     threadAttach();
     ca_clear_channel(channelID);

--- a/src/ca/caChannel.h
+++ b/src/ca/caChannel.h
@@ -22,8 +22,7 @@ namespace epics {
 namespace pvAccess {
 namespace ca {
 
-class CAChannel;
-typedef std::tr1::shared_ptr<CAChannel> CAChannelPtr;
+
 class CAChannelGetField;
 typedef std::tr1::shared_ptr<CAChannelGetField> CAChannelGetFieldPtr;
 typedef std::tr1::weak_ptr<CAChannelGetField> CAChannelGetFieldWPtr;
@@ -60,7 +59,7 @@ public:
 
     static size_t num_instances;
 
-    static shared_pointer create(CAChannelProvider::shared_pointer const & channelProvider,
+    static CAChannelPtr create(CAChannelProvider::shared_pointer const & channelProvider,
                                  std::string const & channelName,
                                  short priority,
                                  ChannelRequester::shared_pointer const & channelRequester);
@@ -112,6 +111,7 @@ public:
     void addChannelGet(const CAChannelGetPtr & get);
     void addChannelPut(const CAChannelPutPtr & get);
     void addChannelMonitor(const CAChannelMonitorPtr & get);
+    void disconnectChannel();
 
 
 private:
@@ -129,6 +129,7 @@ private:
     chid channelID;
     chtype channelType;
     unsigned elementCount;
+    bool channelCreated;
     epics::pvData::Structure::const_shared_pointer structure;
 
     epics::pvData::Mutex requestsMutex;

--- a/src/ca/caProvider.cpp
+++ b/src/ca/caProvider.cpp
@@ -190,9 +190,7 @@ void ca_factory_cleanup(void*)
         ChannelProviderRegistry::clients()->remove("ca");
         ca_context_destroy(); 
     } catch(std::exception& e) {
-        std::string message("Error when unregister \"ca\" factory");
-        message += e.what();
-        LOG(logLevelWarn,message.c_str());
+        LOG(logLevelWarn, "Error on unregistering \"ca\" factory: %s", e.what());
     }
 }
 

--- a/src/ca/caProviderPvt.h
+++ b/src/ca/caProviderPvt.h
@@ -19,6 +19,10 @@ namespace ca {
 
 #define DEBUG_LEVEL 0
 
+class CAChannel;
+typedef std::tr1::shared_ptr<CAChannel> CAChannelPtr;
+typedef std::tr1::weak_ptr<CAChannel> CAChannelWPtr;
+
 class CAChannelProvider;
 typedef std::tr1::shared_ptr<CAChannelProvider> CAChannelProviderPtr;
 typedef std::tr1::weak_ptr<CAChannelProvider> CAChannelProviderWPtr;
@@ -64,13 +68,18 @@ public:
 
     virtual void destroy() EPICS_DEPRECATED {};
 
+    void addChannel(const CAChannelPtr & get);
+
     /* ---------------------------------------------------------------- */
 
     void threadAttach();
+    
 
 private:
     void initialize();
     ca_client_context* current_context;
+    epics::pvData::Mutex channelListMutex;
+    std::vector<CAChannelWPtr> caChannelList;
 };
 
 }


### PR DESCRIPTION
Make sure that when CACProvider is destroyed that ca_clear_channel has been called for all channels.