### PR TITLE
Revert "When caProvider is destroyed make sure all channels are cleared"

### DIFF
--- a/src/ca/caChannel.cpp
+++ b/src/ca/caChannel.cpp
@@ -374,8 +374,7 @@ CAChannel::CAChannel(std::string const & _channelName,
     channelRequester(_channelRequester),
     channelID(0),
     channelType(0),
-    elementCount(0),
-    channelCreated(false)
+    elementCount(0)
 {
     if(DEBUG_LEVEL>0) {
           cout<< "CAChannel::CAChannel " << channelName << endl;
@@ -396,42 +395,12 @@ void CAChannel::activate(short priority)
                                    &channelID);
     if (result == ECA_NORMAL)
     {
-       channelCreated = true;
-       CAChannelProviderPtr provider(channelProvider.lock());
-       if(provider) provider->addChannel(shared_from_this());
        req->channelCreated(Status::Ok, shared_from_this());
     } else {
         Status errorStatus(Status::STATUSTYPE_ERROR, string(ca_message(result)));
         req->channelCreated(errorStatus, shared_from_this());
     }
 }
-
-CAChannel::~CAChannel()
-{
-    if(DEBUG_LEVEL>0) {
-        cout << "CAChannel::~CAChannel() " << channelName << endl;
-    }
-    disconnectChannel();
-}
-
-void CAChannel::disconnectChannel()
-{
-    if(DEBUG_LEVEL>0) {
-        cout << "CAChannel::disconnectChannel() "
-             << channelName 
-             << " channelCreated " << (channelCreated ? "true" : "false")
-             << endl;
-    }
-    {
-        Lock lock(requestsMutex);
-        if(!channelCreated) return;
-    }
-    /* Clear CA Channel */
-    threadAttach();
-    ca_clear_channel(channelID);
-}
-
-
 
 void CAChannel::addChannelGet(const CAChannelGetPtr & get)
 {
@@ -478,6 +447,17 @@ void CAChannel::addChannelMonitor(const CAChannelMonitorPtr & monitor)
     }
     monitorList.push_back(monitor);
 }
+
+CAChannel::~CAChannel()
+{
+    if(DEBUG_LEVEL>0) {
+        cout << "CAChannel::~CAChannel() " << channelName << endl;
+    }
+    /* Clear CA Channel */
+    threadAttach();
+    ca_clear_channel(channelID);
+}
+
 
 chid CAChannel::getChannelID()
 {

--- a/src/ca/caChannel.h
+++ b/src/ca/caChannel.h
@@ -22,7 +22,8 @@ namespace epics {
 namespace pvAccess {
 namespace ca {
 
-
+class CAChannel;
+typedef std::tr1::shared_ptr<CAChannel> CAChannelPtr;
 class CAChannelGetField;
 typedef std::tr1::shared_ptr<CAChannelGetField> CAChannelGetFieldPtr;
 typedef std::tr1::weak_ptr<CAChannelGetField> CAChannelGetFieldWPtr;
@@ -59,7 +60,7 @@ public:
 
     static size_t num_instances;
 
-    static CAChannelPtr create(CAChannelProvider::shared_pointer const & channelProvider,
+    static shared_pointer create(CAChannelProvider::shared_pointer const & channelProvider,
                                  std::string const & channelName,
                                  short priority,
                                  ChannelRequester::shared_pointer const & channelRequester);
@@ -111,7 +112,6 @@ public:
     void addChannelGet(const CAChannelGetPtr & get);
     void addChannelPut(const CAChannelPutPtr & get);
     void addChannelMonitor(const CAChannelMonitorPtr & get);
-    void disconnectChannel();
 
 
 private:
@@ -129,7 +129,6 @@ private:
     chid channelID;
     chtype channelType;
     unsigned elementCount;
-    bool channelCreated;
     epics::pvData::Structure::const_shared_pointer structure;
 
     epics::pvData::Mutex requestsMutex;

--- a/src/ca/caProviderPvt.h
+++ b/src/ca/caProviderPvt.h
@@ -19,10 +19,6 @@ namespace ca {
 
 #define DEBUG_LEVEL 0
 
-class CAChannel;
-typedef std::tr1::shared_ptr<CAChannel> CAChannelPtr;
-typedef std::tr1::weak_ptr<CAChannel> CAChannelWPtr;
-
 class CAChannelProvider;
 typedef std::tr1::shared_ptr<CAChannelProvider> CAChannelProviderPtr;
 typedef std::tr1::weak_ptr<CAChannelProvider> CAChannelProviderWPtr;
@@ -68,18 +64,13 @@ public:
 
     virtual void destroy() EPICS_DEPRECATED {};
 
-    void addChannel(const CAChannelPtr & get);
-
     /* ---------------------------------------------------------------- */
 
     void threadAttach();
-    
 
 private:
     void initialize();
     ca_client_context* current_context;
-    epics::pvData::Mutex channelListMutex;
-    std::vector<CAChannelWPtr> caChannelList;
 };
 
 }


### PR DESCRIPTION
Reverts epics-base/pvAccessCPP#79