### PR TITLE
termination and error handling changes.

### DIFF
--- a/src/ca/caChannel.h
+++ b/src/ca/caChannel.h
@@ -106,7 +106,7 @@ public:
 
     /* ---------------------------------------------------------------- */
 
-    void threadAttach();
+    void attachContext();
 
     void addChannelGet(const CAChannelGetPtr & get);
     void addChannelPut(const CAChannelPutPtr & get);

--- a/src/ca/caProvider.cpp
+++ b/src/ca/caProvider.cpp
@@ -169,7 +169,11 @@ void CAChannelProvider::poll()
 
 void CAChannelProvider::attachContext()
 {
-    if(ca_current_context()) return;
+    ca_client_context* thread_context = ca_current_context();
+    if (thread_context == current_context) return;
+    if (thread_context != NULL) {
+        throw std::runtime_error("CAChannelProvider: Foreign CA context in use");
+    }
     int result = ca_attach_context(current_context);
     if (result != ECA_NORMAL) {
         std::cout <<

--- a/src/ca/caProviderPvt.h
+++ b/src/ca/caProviderPvt.h
@@ -68,12 +68,11 @@ public:
 
     virtual void destroy() EPICS_DEPRECATED {};
 
-    void addChannel(const CAChannelPtr & get);
+    void addChannel(const CAChannelPtr & channel);
 
     /* ---------------------------------------------------------------- */
 
-    void threadAttach();
-    
+    void attachContext();
 
 private:
     void initialize();

--- a/src/ca/caProviderPvt.h
+++ b/src/ca/caProviderPvt.h
@@ -73,7 +73,7 @@ public:
     void attachContext();
 
 private:
-    virtual void destroy() EPICS_DEPRECATED {};
+    virtual void destroy() EPICS_DEPRECATED {}
     void initialize();
     ca_client_context* current_context;
     epics::pvData::Mutex channelListMutex;


### PR DESCRIPTION
 epicsAtExit is no longer used to call ca_context_destroy.
 It is now called from the destructor for CAChannelProvider.
    
 Several changes were made for handling errors.

also  merged with latest from epics-base
