### PR TITLE
server: pipeline=true windowing

### DIFF
--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -2154,7 +2154,6 @@ void ServerMonitorRequesterImpl::send(ByteBuffer* buffer, TransportSendControl* 
         }
         else
         {
-            // TODO CAS
             bool unlisten;
             window_t window;
             {
@@ -2167,7 +2166,10 @@ void ServerMonitorRequesterImpl::send(ByteBuffer* buffer, TransportSendControl* 
                 }
             }
 
-            window.clear(); // calls Monitor::release()
+            for(window_t::iterator it(window.begin()), end(window.end()); it!=end; ++it) {
+                monitor->release(*it);
+            }
+            window.clear();
 
             if (unlisten)
             {


### PR DESCRIPTION
Implement flow control windows in the server itself, so that this applies to all Monitor,
even those which have no awareness of the flow control window.

Then the reportRemoteQueueStatus() callback is only needed to deliver the initial window update in order to keep track of the window size.

This is done by not calling Monitor::release() immediately when pipeline=true.  Rather, hold onto MonitorElement s until an ack is received.

Also addresses a race with clearing _channelMonitor vs. having send() queued at/after destroy().