### PR TITLE
Changing default request string to 'field()'

### DIFF
--- a/pvtoolsSrc/pvget.cpp
+++ b/pvtoolsSrc/pvget.cpp
@@ -42,7 +42,7 @@ namespace {
 
 bool debugFlag = false;
 
-string request("field(value)");
+string request("field()");
 string defaultProvider("pva");
 
 enum PrintMode { ValueOnlyMode, StructureMode, TerseMode };
@@ -80,7 +80,7 @@ void printValue(std::string const & channelName, PVStructure::shared_pointer con
         PVField::shared_pointer value = pv->getSubField("value");
         if (value.get() == 0)
         {
-            std::cerr << "no 'value' field\n";
+            //std::cerr << "no 'value' field\n";
             pvutil_ostream myos(std::cout);
             myos << channelName << "\n" << *(pv.get()) << "\n\n";
         }


### PR DESCRIPTION
The default request string was changed from "field(value)" to "field()".

This allows ```pvget pv_name``` to work regardless if the pv has a value field or not. This is in line with the original pvget in which the entire pv structure would be dumped to stdout if the pv did not have a value field.

This unfortunately entails requesting the entire pv structure every time, but I could not figure out a way to modify the current form of pvget to check the structure and reissue a new request if the structure lacks a value field.