### PR TITLE
pva/client.h updates

### DIFF
--- a/src/client/Makefile
+++ b/src/client/Makefile
@@ -11,5 +11,6 @@ pvAccess_SRCS += monitor.cpp
 pvAccess_SRCS += client.cpp
 pvAccess_SRCS += clientSync.cpp
 pvAccess_SRCS += clientGet.cpp
+pvAccess_SRCS += clientPut.cpp
 pvAccess_SRCS += clientRPC.cpp
 pvAccess_SRCS += clientMonitor.cpp

--- a/src/client/Makefile
+++ b/src/client/Makefile
@@ -14,3 +14,4 @@ pvAccess_SRCS += clientGet.cpp
 pvAccess_SRCS += clientPut.cpp
 pvAccess_SRCS += clientRPC.cpp
 pvAccess_SRCS += clientMonitor.cpp
+pvAccess_SRCS += clientInfo.cpp

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -219,6 +219,7 @@ void register_reftrack()
     // done is an optimization, duplicate calls to registerRef* are no-ops
     pvac::detail::registerRefTrack();
     pvac::detail::registerRefTrackGet();
+    pvac::detail::registerRefTrackPut();
     pvac::detail::registerRefTrackMonitor();
     pvac::detail::registerRefTrackRPC();
 }

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -222,6 +222,7 @@ void register_reftrack()
     pvac::detail::registerRefTrackPut();
     pvac::detail::registerRefTrackMonitor();
     pvac::detail::registerRefTrackRPC();
+    pvac::detail::registerRefTrackInfo();
 }
 
 std::tr1::shared_ptr<epics::pvAccess::Channel>

--- a/src/client/clientInfo.cpp
+++ b/src/client/clientInfo.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright information and license terms for this software can be
+ * found in the file LICENSE that is included with the distribution
+ */
+
+#include <epicsMutex.h>
+#include <epicsGuard.h>
+#include <epicsEvent.h>
+
+#include <pv/current_function.h>
+#include <pv/pvData.h>
+#include <pv/bitSet.h>
+#include <pv/reftrack.h>
+
+#define epicsExportSharedSymbols
+#include "pv/logger.h"
+#include "clientpvt.h"
+#include "pv/pvAccess.h"
+
+namespace {
+using pvac::detail::CallbackGuard;
+using pvac::detail::CallbackUse;
+
+struct Infoer : public pvac::detail::CallbackStorage,
+                public pva::GetFieldRequester,
+                public pvac::Operation::Impl,
+                public pvac::detail::wrapped_shared_from_this<Infoer>
+{
+    pvac::ClientChannel::InfoCallback *cb;
+    const pva::Channel::shared_pointer channel;
+
+    static size_t num_instances;
+
+    explicit Infoer(pvac::ClientChannel::InfoCallback *cb, const pva::Channel::shared_pointer& channel)
+        :cb(cb), channel(channel)
+    {REFTRACE_INCREMENT(num_instances);}
+    virtual ~Infoer() {
+        CallbackGuard G(*this);
+        cb = 0;
+        G.wait(); // paranoia
+        REFTRACE_DECREMENT(num_instances);
+    }
+
+
+    virtual std::string getRequesterName() OVERRIDE FINAL
+    {
+        Guard G(mutex);
+        return channel->getChannelName();
+    }
+
+    virtual void getDone(
+        const pvd::Status& status,
+        pvd::FieldConstPtr const & field) OVERRIDE FINAL
+    {
+        CallbackGuard G(*this);
+        pvac::ClientChannel::InfoCallback *C(cb);
+        cb = 0;
+        if(C) {
+            pvac::InfoEvent evt;
+            evt.event = status.isSuccess() ? pvac::InfoEvent::Success : pvac::InfoEvent::Fail;
+            evt.message = status.getMessage();
+            evt.type = field;
+            CallbackUse U(G);
+            C->infoDone(evt);
+        }
+        pvac::InfoEvent evt;
+    }
+
+    virtual std::string name() const OVERRIDE FINAL { return channel->getChannelName(); }
+
+    virtual void cancel() OVERRIDE FINAL {
+        CallbackGuard G(*this);
+        // we can't actually cancel a getField
+        pvac::ClientChannel::InfoCallback *C(cb);
+        cb = 0;
+        if(C) {
+            pvac::InfoEvent evt;
+            evt.event = pvac::InfoEvent::Cancel;
+            CallbackUse U(G);
+            C->infoDone(evt);
+        }
+        G.wait();
+    }
+
+    virtual void show(std::ostream& strm) const OVERRIDE FINAL {
+        strm << "Operation(Info"
+                "\"" << name() <<"\""
+             ")";
+    }
+};
+
+size_t Infoer::num_instances;
+
+} // namespace
+
+namespace pvac {
+
+Operation ClientChannel::info(InfoCallback *cb, const std::string& subfld)
+{
+    if(!impl) throw std::logic_error("Dead Channel");
+
+    std::tr1::shared_ptr<Infoer> ret(Infoer::build(cb, getChannel()));
+
+    {
+        Guard G(ret->mutex);
+        getChannel()->getField(ret, subfld);
+        // getField is an oddity as it doesn't have an associated Operation class,
+        // and is thus largely out of our control.  (eg. can't cancel)
+    }
+
+    return Operation(ret);
+}
+
+namespace detail {
+
+void registerRefTrackInfo()
+{
+    epics::registerRefCounter("pvac::Infoer", &Infoer::num_instances);
+}
+
+}
+
+} // namespace pvac

--- a/src/client/clientMonitor.cpp
+++ b/src/client/clientMonitor.cpp
@@ -16,11 +16,6 @@
 #include "clientpvt.h"
 #include "pv/pvAccess.h"
 
-namespace pvd = epics::pvData;
-namespace pva = epics::pvAccess;
-typedef epicsGuard<epicsMutex> Guard;
-typedef epicsGuardRelease<epicsMutex> UnGuard;
-
 namespace pvac {
 
 struct Monitor::Impl : public pva::MonitorRequester,

--- a/src/client/clientMonitor.cpp
+++ b/src/client/clientMonitor.cpp
@@ -5,6 +5,7 @@
 
 #include <epicsMutex.h>
 #include <epicsGuard.h>
+#include <epicsEvent.h>
 
 #include <pv/current_function.h>
 #include <pv/pvData.h>
@@ -17,11 +18,13 @@
 #include "pv/pvAccess.h"
 
 namespace pvac {
+using pvac::detail::CallbackGuard;
+using pvac::detail::CallbackUse;
 
-struct Monitor::Impl : public pva::MonitorRequester,
+struct Monitor::Impl : public pvac::detail::CallbackStorage,
+                       public pva::MonitorRequester,
                        public pvac::detail::wrapped_shared_from_this<Monitor::Impl>
 {
-    mutable epicsMutex mutex;
     pva::Channel::shared_pointer chan;
     operation_type::shared_pointer op;
     bool started, done, seenEmpty;
@@ -39,9 +42,14 @@ struct Monitor::Impl : public pva::MonitorRequester,
         ,seenEmpty(false)
         ,cb(cb)
     {REFTRACE_INCREMENT(num_instances);}
-    virtual ~Impl() {REFTRACE_DECREMENT(num_instances);}
+    virtual ~Impl() {
+        CallbackGuard G(*this);
+        cb = 0;
+        G.wait(); // paranoia
+        REFTRACE_DECREMENT(num_instances);
+    }
 
-    void callEvent(Guard& G, MonitorEvent::event_t evt = MonitorEvent::Fail)
+    void callEvent(CallbackGuard& G, MonitorEvent::event_t evt = MonitorEvent::Fail)
     {
         ClientChannel::MonitorCallback *cb=this->cb;
         if(!cb) return;
@@ -52,7 +60,7 @@ struct Monitor::Impl : public pva::MonitorRequester,
             this->cb = 0; // last event
 
         try {
-            UnGuard U(G);
+            CallbackUse U(G);
             cb->monitorEvent(event);
             return;
         }catch(std::exception& e){
@@ -66,7 +74,7 @@ struct Monitor::Impl : public pva::MonitorRequester,
         }
         // continues error handling
         try {
-            UnGuard U(G);
+            CallbackUse U(G);
             cb->monitorEvent(event);
             return;
         }catch(std::exception& e){
@@ -82,7 +90,7 @@ struct Monitor::Impl : public pva::MonitorRequester,
             // keepalive for safety in case callback wants to destroy us
             std::tr1::shared_ptr<Monitor::Impl> keepalive(internal_shared_from_this());
 
-            Guard G(mutex);
+            CallbackGuard G(*this);
 
             last.reset();
 
@@ -93,6 +101,7 @@ struct Monitor::Impl : public pva::MonitorRequester,
             temp.swap(op);
 
             callEvent(G, MonitorEvent::Cancel);
+            G.wait();
         }
         if(temp)
             temp->destroy();
@@ -110,7 +119,7 @@ struct Monitor::Impl : public pva::MonitorRequester,
                                 pvd::StructureConstPtr const & structure) OVERRIDE FINAL
     {
         std::tr1::shared_ptr<Monitor::Impl> keepalive(internal_shared_from_this());
-        Guard G(mutex);
+        CallbackGuard G(*this);
         if(!cb || started || done) return;
 
         if(!status.isOK()) {
@@ -140,7 +149,7 @@ struct Monitor::Impl : public pva::MonitorRequester,
     virtual void channelDisconnect(bool destroy) OVERRIDE FINAL
     {
         std::tr1::shared_ptr<Monitor::Impl> keepalive(internal_shared_from_this());
-        Guard G(mutex);
+        CallbackGuard G(*this);
         if(!cb || done) return;
         event.message = "Disconnect";
         started = false;
@@ -150,7 +159,7 @@ struct Monitor::Impl : public pva::MonitorRequester,
     virtual void monitorEvent(pva::MonitorPtr const & monitor) OVERRIDE FINAL
     {
         std::tr1::shared_ptr<Monitor::Impl> keepalive(internal_shared_from_this());
-        Guard G(mutex);
+        CallbackGuard G(*this);
         if(!cb || done) return;
         event.message.clear();
 
@@ -160,7 +169,7 @@ struct Monitor::Impl : public pva::MonitorRequester,
     virtual void unlisten(pva::MonitorPtr const & monitor) OVERRIDE FINAL
     {
         std::tr1::shared_ptr<Monitor::Impl> keepalive(internal_shared_from_this());
-        Guard G(mutex);
+        CallbackGuard G(*this);
         if(!cb || done) return;
         done = true;
 

--- a/src/client/clientPut.cpp
+++ b/src/client/clientPut.cpp
@@ -1,0 +1,233 @@
+/*
+ * Copyright information and license terms for this software can be
+ * found in the file LICENSE that is included with the distribution
+ */
+
+#include <epicsMutex.h>
+#include <epicsGuard.h>
+#include <epicsEvent.h>
+
+#include <pv/current_function.h>
+#include <pv/pvData.h>
+#include <pv/bitSet.h>
+#include <pv/reftrack.h>
+
+#define epicsExportSharedSymbols
+#include "pv/logger.h"
+#include "clientpvt.h"
+#include "pv/pvAccess.h"
+
+namespace pvd = epics::pvData;
+namespace pva = epics::pvAccess;
+typedef epicsGuard<epicsMutex> Guard;
+typedef epicsGuardRelease<epicsMutex> UnGuard;
+
+namespace {
+
+struct Putter : public pva::ChannelPutRequester,
+                   public pvac::Operation::Impl,
+                   public pvac::detail::wrapped_shared_from_this<Putter>
+{
+    mutable epicsMutex mutex;
+
+    const bool getcurrent;
+
+    bool started; // whether the put() has actually been sent.  After which point we can't safely re-try.
+    operation_type::shared_pointer op;
+    pvd::StructureConstPtr puttype;
+
+    pvac::ClientChannel::PutCallback *putcb;
+    pvac::GetEvent event;
+
+    static size_t num_instances;
+
+    Putter(pvac::ClientChannel::PutCallback* cb, bool getcurrent) :getcurrent(getcurrent), started(false), putcb(cb)
+    {REFTRACE_INCREMENT(num_instances);}
+    virtual ~Putter() {REFTRACE_DECREMENT(num_instances);}
+
+    void callEvent(Guard& G, pvac::GetEvent::event_t evt = pvac::GetEvent::Fail)
+    {
+        if(!putcb) return;
+
+        event.event = evt;
+        pvac::ClientChannel::PutCallback *cb=putcb;
+        putcb = 0;
+        UnGuard U(G);
+        cb->putDone(event);
+    }
+
+    virtual std::string name() const OVERRIDE FINAL
+    {
+        Guard G(mutex);
+        return op ? op->getChannel()->getChannelName() : "<dead>";
+    }
+
+    // called automatically via wrapped_shared_from_this
+    virtual void cancel() OVERRIDE FINAL
+    {
+        // keepalive for safety in case callback wants to destroy us
+        std::tr1::shared_ptr<Putter> keepalive(internal_shared_from_this());
+        Guard G(mutex);
+        if(started && op) op->cancel();
+        callEvent(G, pvac::GetEvent::Cancel);
+    }
+
+    virtual std::string getRequesterName() OVERRIDE FINAL
+    {
+        Guard G(mutex);
+        return op ? op->getChannel()->getRequesterName() : "<dead>";
+    }
+
+    virtual void channelPutConnect(
+        const epics::pvData::Status& status,
+        pva::ChannelPut::shared_pointer const & channelPut,
+        epics::pvData::Structure::const_shared_pointer const & structure) OVERRIDE FINAL
+    {
+        std::tr1::shared_ptr<Putter> keepalive(internal_shared_from_this());
+        Guard G(mutex);
+        op = channelPut; // we may be called before createChannelPut() has returned.
+        puttype = structure;
+        if(started || !putcb) return;
+
+        if(!status.isOK()) {
+            event.message = status.getMessage();
+        } else {
+            event.message.clear();
+        }
+        if(!status.isSuccess()) {
+            callEvent(G);
+
+        } else if(getcurrent) {
+            // fetch a previous value first
+            op->get();
+        } else {
+            // build Put value immediately
+            pvd::BitSet empty;
+            pvd::BitSet::shared_pointer tosend(new pvd::BitSet);
+            pvac::ClientChannel::PutCallback::Args args(*tosend, empty);
+            // args.previous = 0; // implied
+            doPut(G, args, channelPut, tosend);
+        }
+    }
+
+    virtual void channelDisconnect(bool destroy) OVERRIDE FINAL
+    {
+        Guard G(mutex);
+        event.message = "Disconnect";
+
+        callEvent(G);
+    }
+
+    void doPut(Guard& G,
+               pvac::ClientChannel::PutCallback::Args& args,
+               pva::ChannelPut::shared_pointer const & channelPut,
+               const pvd::BitSet::shared_pointer& tosend)
+    {
+        try {
+            pvac::ClientChannel::PutCallback *cb(putcb);
+            UnGuard U(G);
+            cb->putBuild(puttype, args);
+            if(!args.root)
+                throw std::logic_error("No put value provided");
+            else if(*args.root->getStructure()!=*puttype)
+                throw std::logic_error("Provided put value with wrong type");
+        }catch(std::exception& e){
+            if(putcb) {
+                event.message = e.what();
+                callEvent(G);
+            } else {
+                LOG(pva::logLevelInfo, "Lost exception in %s: %s", CURRENT_FUNCTION, e.what());
+            }
+        }
+        // check putcb again after UnGuard
+        if(putcb) {
+            channelPut->put(std::tr1::const_pointer_cast<pvd::PVStructure>(args.root), tosend);
+            started = true;
+        }
+    }
+
+    virtual void getDone(
+        const epics::pvData::Status& status,
+        pva::ChannelPut::shared_pointer const & channelPut,
+        epics::pvData::PVStructure::shared_pointer const & pvStructure,
+        epics::pvData::BitSet::shared_pointer const & bitSet) OVERRIDE FINAL
+    {
+        std::tr1::shared_ptr<Putter> keepalive(internal_shared_from_this());
+        Guard G(mutex);
+        if(!putcb) return;
+
+        if(!status.isOK()) {
+            event.message = status.getMessage();
+
+            callEvent(G, pvac::GetEvent::Fail);
+
+        } else {
+            pvd::BitSet::shared_pointer tosend(new pvd::BitSet);
+            pvac::ClientChannel::PutCallback::Args args(*tosend, *bitSet);
+            args.previous = pvStructure;
+            doPut(G, args, channelPut, tosend);
+        }
+    }
+
+    virtual void putDone(
+        const epics::pvData::Status& status,
+        pva::ChannelPut::shared_pointer const & channelPut) OVERRIDE FINAL
+    {
+        std::tr1::shared_ptr<Putter> keepalive(internal_shared_from_this());
+        Guard G(mutex);
+        if(!putcb) return;
+
+        if(!status.isOK()) {
+            event.message = status.getMessage();
+        } else {
+            event.message.clear();
+        }
+
+        callEvent(G, status.isSuccess()? pvac::GetEvent::Success : pvac::GetEvent::Fail);
+    }
+
+    virtual void show(std::ostream &strm) const
+    {
+        strm << "Operation(Put"
+                "\"" << name() <<"\""
+             ")";
+    }
+};
+
+size_t Putter::num_instances;
+
+} //namespace
+
+namespace pvac {
+
+Operation
+ClientChannel::put(PutCallback* cb,
+                   epics::pvData::PVStructure::const_shared_pointer pvRequest,
+                   bool getcurrent)
+{
+    if(!impl) throw std::logic_error("Dead Channel");
+    if(!pvRequest)
+        pvRequest = pvd::createRequest("field()");
+
+    std::tr1::shared_ptr<Putter> ret(Putter::build(cb, getcurrent));
+
+    {
+        Guard G(ret->mutex);
+        ret->op = getChannel()->createChannelPut(ret->internal_shared_from_this(),
+                                                 std::tr1::const_pointer_cast<pvd::PVStructure>(pvRequest));
+    }
+
+    return Operation(ret);
+
+}
+
+namespace detail {
+
+void registerRefTrackPut()
+{
+    epics::registerRefCounter("pvac::Putter", &Putter::num_instances);
+}
+
+}
+
+}//namespace pvac

--- a/src/client/clientRPC.cpp
+++ b/src/client/clientRPC.cpp
@@ -15,11 +15,6 @@
 #include "clientpvt.h"
 #include "pv/pvAccess.h"
 
-namespace pvd = epics::pvData;
-namespace pva = epics::pvAccess;
-typedef epicsGuard<epicsMutex> Guard;
-typedef epicsGuardRelease<epicsMutex> UnGuard;
-
 namespace {
 
 struct RPCer : public pva::ChannelRPCRequester,

--- a/src/client/clientpvt.h
+++ b/src/client/clientpvt.h
@@ -67,6 +67,7 @@ public:
 
 void registerRefTrack();
 void registerRefTrackGet();
+void registerRefTrackPut();
 void registerRefTrackMonitor();
 void registerRefTrackRPC();
 

--- a/src/client/clientpvt.h
+++ b/src/client/clientpvt.h
@@ -1,6 +1,9 @@
 #ifndef CLIENTPVT_H
 #define CLIENTPVT_H
 
+#include <epicsEvent.h>
+#include <epicsThread.h>
+
 #include <pv/sharedPtr.h>
 
 #include <pva/client.h>
@@ -69,6 +72,89 @@ public:
         return ret;
     }
 };
+
+/** Safe use of raw callback pointer while unlocked.
+ * clear pointer and then call CallbackGuard::wait() to ensure that concurrent
+ * callback have completed.
+ *
+ * Prototype usage
+ @code
+ * struct mycb : public CallbackStorage {
+ *      void (*ptr)();
+ * };
+ * // make a callback
+ * void docb(mycb& cb) {
+ *     CallbackGuard G(cb); // lock
+ *     // decide whether to make CB
+ *     if(P){
+ *          void (*P)() = ptr; // copy for use while unlocked
+ *          CallbackUse U(G); // unlock
+ *          (*P)();
+ *          // automatic re-lock
+ *     }
+ *     // automatic final unlock
+ * }
+ * void cancelop(mycb& cb) {
+ *     CallbackGuard G(cb);
+ *     ptr = 0;  // prevent further callbacks from starting
+ *     G.wait(); // wait for inprogress callbacks to complete
+ * }
+ @endcode
+ */
+struct CallbackStorage {
+    mutable epicsMutex mutex;
+    epicsEvent wakeup;
+    size_t nwaitcb;
+    epicsThreadId incb;
+    CallbackStorage() :nwaitcb(0u), incb(0) {}
+};
+
+// analogous to epicsGuard
+struct CallbackGuard {
+    CallbackStorage& store;
+    epicsThreadId self;
+    explicit CallbackGuard(CallbackStorage& store) :store(store), self(0) {
+        store.mutex.lock();
+    }
+    ~CallbackGuard() {
+        bool notify = store.nwaitcb!=0;
+        store.mutex.unlock();
+        if(notify)
+            store.wakeup.signal();
+    }
+    void ensureself() {
+        if(!self)
+            self = epicsThreadGetIdSelf();
+    }
+    // unlock and block until no in-progress callbacks
+    void wait() {
+        if(!store.incb) return;
+        ensureself();
+        store.nwaitcb++;
+        while(store.incb && store.incb!=self) {
+            store.mutex.unlock();
+            store.wakeup.wait();
+            store.mutex.lock();
+        }
+        store.nwaitcb--;
+    }
+};
+
+// analogous to epicsGuardRelease
+struct CallbackUse {
+    CallbackGuard& G;
+    explicit CallbackUse(CallbackGuard& G) :G(G) {
+        G.wait(); // serialize callbacks
+        G.ensureself();
+        G.store.incb=G.self;
+        G.store.mutex.unlock();
+    }
+    ~CallbackUse() {
+        G.store.mutex.lock();
+        G.store.incb=0;
+    }
+};
+
 
 void registerRefTrack();
 void registerRefTrackGet();

--- a/src/client/clientpvt.h
+++ b/src/client/clientpvt.h
@@ -161,6 +161,7 @@ void registerRefTrackGet();
 void registerRefTrackPut();
 void registerRefTrackMonitor();
 void registerRefTrackRPC();
+void registerRefTrackInfo();
 
 }} // namespace pvac::detail
 

--- a/src/client/clientpvt.h
+++ b/src/client/clientpvt.h
@@ -5,6 +5,11 @@
 
 #include <pva/client.h>
 
+namespace pvd = epics::pvData;
+namespace pva = epics::pvAccess;
+typedef epicsGuard<epicsMutex> Guard;
+typedef epicsGuardRelease<epicsMutex> UnGuard;
+
 namespace pvac{namespace detail{
 /* Like std::tr1::enable_shared_from_this
  * with the notion of internal vs. external references.

--- a/src/client/pva/client.h
+++ b/src/client/pva/client.h
@@ -85,7 +85,7 @@ protected:
 };
 
 //! Information on put completion
-struct PutEvent
+struct epicsShareClass PutEvent
 {
     enum event_t {
         Fail,    //!< request ends in failure.  Check message
@@ -103,6 +103,12 @@ struct epicsShareClass GetEvent : public PutEvent
     //! Mask of fields in value which have been initialized by the server
     //! @since 6.1.0
     epics::pvData::BitSet::const_shared_pointer valid;
+};
+
+struct epicsShareClass InfoEvent : public PutEvent
+{
+    //! Type description resulting from getField operation.  NULL unless event==Success
+    epics::pvData::FieldConstPtr type;
 };
 
 struct MonitorSync;
@@ -415,6 +421,20 @@ public:
      */
     MonitorSync monitor(const epics::pvData::PVStructure::const_shared_pointer& pvRequest = epics::pvData::PVStructure::const_shared_pointer(),
                         epicsEvent *event =0);
+
+    struct InfoCallback {
+        virtual ~InfoCallback() {}
+        //! getField operation is complete
+        virtual void infoDone(const InfoEvent& evt) =0;
+    };
+
+    //! Request PV type info.
+    //! @note This type may not be the same as the types used in the get/put/monitor operations.
+    Operation info(InfoCallback *cb, const std::string& subfld = std::string());
+
+    //! Synchronious getField opreation
+    epics::pvData::FieldConstPtr info(double timeout = 3.0,
+                                      const std::string& subfld = std::string());
 
     //! Connection state change CB
     struct ConnectCallback {


### PR DESCRIPTION
Two features with a bug fix sandwiched between them.

1. Change handling of ```ChannelGet::get()``` vs ```ChannelPut::get()``` noted in https://github.com/epics-base/pvAccessCPP/issues/115#issuecomment-406002956
2. Fix a possible use after free race when canceling an Operation or Monitor.
3. Add a way to issue ```Channel::getField()``` as ```pvac::ClientChannel::info()```.

In the first, ```pvac::ClientChannel::get()``` now issues a ```ChannelGet::get()```.   ```pvac::ClientChannel::put()``` can be made to first issue ```ChannelPut::get()``` and present the result to the putBuilder callback.