### PR TITLE
Deprecate protocol version 0

### DIFF
--- a/pvtoolsSrc/pvlist.cpp
+++ b/pvtoolsSrc/pvlist.cpp
@@ -120,6 +120,10 @@ bool processSearchResponse(osiSockAddr const & responseFrom, ByteBuffer & receiv
 
     // second byte version
     int8 version = receiveBuffer.getByte();
+    if(version == 0) {
+        // 0 -> 1 included incompatible changes
+        return false;
+    }
 
     // only data for UDP
     int8 flags = receiveBuffer.getByte();

--- a/src/remote/abstractResponseHandler.cpp
+++ b/src/remote/abstractResponseHandler.cpp
@@ -4,8 +4,6 @@
  * in file LICENSE that is included with this distribution.
  */
 
-#include <sstream>
-
 #include <osiSock.h>
 
 #include <pv/byteBuffer.h>
@@ -14,9 +12,6 @@
 #define epicsExportSharedSymbols
 #include <pv/remote.h>
 #include <pv/hexDump.h>
-
-using std::ostringstream;
-using std::hex;
 
 using namespace epics::pvData;
 
@@ -44,13 +39,10 @@ void ResponseHandler::handleResponse(osiSockAddr* responseFrom,
         char ipAddrStr[48];
         ipAddrToDottedIP(&responseFrom->ia, ipAddrStr, sizeof(ipAddrStr));
 
-        ostringstream prologue;
-        prologue<<"Message [0x"<<hex<<(int)command<<", v0x"<<hex;
-        prologue<<(int)version<<"] received from "<<ipAddrStr<<" on "<<transport->getRemoteName();
-
-        hexDump(prologue.str(), _description,
-                (const int8*)payloadBuffer->getArray(),
-                payloadBuffer->getPosition(), static_cast<int>(payloadSize));
+        std::cerr<<"Message [0x"<<std::hex<<(int)command<<", v0x"<<std::hex
+                 <<int(version)<<"] received from "<<ipAddrStr<<" on "<<transport->getRemoteName()
+                 <<" : "<<_description<<"\n"
+                 <<HexDump(*payloadBuffer, payloadSize);
     }
 }
 }

--- a/src/remote/abstractResponseHandler.cpp
+++ b/src/remote/abstractResponseHandler.cpp
@@ -42,7 +42,7 @@ void ResponseHandler::handleResponse(osiSockAddr* responseFrom,
         std::cerr<<"Message [0x"<<std::hex<<(int)command<<", v0x"<<std::hex
                  <<int(version)<<"] received from "<<ipAddrStr<<" on "<<transport->getRemoteName()
                  <<" : "<<_description<<"\n"
-                 <<HexDump(*payloadBuffer, payloadSize);
+                 <<HexDump(*payloadBuffer, payloadSize).limit(0xffff);
     }
 }
 }

--- a/src/remote/blockingUDPTransport.cpp
+++ b/src/remote/blockingUDPTransport.cpp
@@ -341,6 +341,10 @@ bool BlockingUDPTransport::processBuffer(Transport::shared_pointer const & trans
 
         // second byte version
         int8 version = receiveBuffer->getByte();
+        if(version==0) {
+            // 0 -> 1 included incompatible changes
+            return false;
+        }
 
         int8 flags = receiveBuffer->getByte();
         if (flags & 0x80)

--- a/src/remote/codec.cpp
+++ b/src/remote/codec.cpp
@@ -183,12 +183,6 @@ void AbstractCodec::processReadNormal()  {
                 return;
             }
 
-            /*
-            hexDump("Header", (const int8*)_socketBuffer.getArray(),
-                    _socketBuffer.getPosition(), PVA_MESSAGE_HEADER_SIZE);
-
-            */
-
             // read header fields
             processHeader();
             bool isControl = ((_flags & 0x01) == 0x01);
@@ -795,14 +789,6 @@ void AbstractCodec::send(ByteBuffer *buffer)
         //int p = buffer.position();
         int bytesSent = write(buffer);
 
-        /*
-        if (IS_LOGGABLE(logLevelTrace)) {
-          hexDump(std::string("AbstractCodec::send WRITE"),
-            (const int8 *)buffer->getArray(),
-            buffer->getPosition(), buffer->getRemaining());
-        }
-        */
-
         if (bytesSent < 0)
         {
             // connection lost
@@ -1320,13 +1306,6 @@ int BlockingTCPTransportCodec::read(epics::pvData::ByteBuffer* dst) {
                              (char*)(dst->getArray()+pos), remaining, 0);
 
         // NOTE: do not log here, you might override SOCKERRNO relevant to recv() operation above
-
-        /*
-        if (IS_LOGGABLE(logLevelTrace)) {
-          hexDump(std::string("READ"),
-            (const int8 *)(dst->getArray()+pos), bytesRead);
-        }
-        */
 
         if(unlikely(bytesRead<=0)) {
 

--- a/src/remote/codec.cpp
+++ b/src/remote/codec.cpp
@@ -157,12 +157,12 @@ void AbstractCodec::processHeader() {
     _payloadSize = _socketBuffer.getInt();
 
     // check magic code
-    if (magicCode != PVA_MAGIC)
+    if (magicCode != PVA_MAGIC || _version==0)
     {
         LOG(logLevelError,
-            "Invalid header received from the client at %s:%d: %s.,"
-            " disconnecting...",
-            __FILE__, __LINE__, inetAddressToString(*getLastReadBufferSocketAddress()).c_str());
+            "Invalid header received from the client : %s %02x%02x%02x%02x disconnecting...",
+            inetAddressToString(*getLastReadBufferSocketAddress()).c_str(),
+            unsigned(magicCode), unsigned(_version), unsigned(_flags), unsigned(_command));
         invalidDataStreamHandler();
         throw invalid_data_stream_exception("invalid header received");
     }

--- a/src/remote/pv/blockingUDP.h
+++ b/src/remote/pv/blockingUDP.h
@@ -145,10 +145,7 @@ public:
 
     virtual void close() OVERRIDE FINAL;
 
-    virtual void ensureData(std::size_t size) OVERRIDE FINAL {
-        if (_receiveBuffer.getRemaining() < size)
-            throw std::underflow_error("no more data in UDP packet");
-    }
+    virtual void ensureData(std::size_t size) OVERRIDE FINAL;
 
     virtual void alignData(std::size_t alignment) OVERRIDE FINAL {
         _receiveBuffer.align(alignment);

--- a/src/remoteClient/clientContextImpl.cpp
+++ b/src/remoteClient/clientContextImpl.cpp
@@ -3000,10 +3000,14 @@ public:
     {
         if (command < 0 || command >= (int8)m_handlerTable.size())
         {
-            // TODO remove debug output
-            char buf[100];
-            sprintf(buf, "Invalid (or unsupported) command %d, its payload", command);
-            hexDump(buf, (const int8*)(payloadBuffer->getArray()), payloadBuffer->getPosition(), payloadSize);
+            LOG(logLevelError,
+                "Invalid (or unsupported) command: %x.", (0xFF&command));
+
+            if(pvAccessIsLoggable(logLevelError)) {
+                std::cerr<<"Invalid PVA header "<<hex<<(int)(0xFF&command)
+                         <<", its payload buffer\n"
+                         <<HexDump(*payloadBuffer, payloadSize);
+            }
             return;
         }
         // delegate

--- a/src/remoteClient/clientContextImpl.cpp
+++ b/src/remoteClient/clientContextImpl.cpp
@@ -3000,13 +3000,9 @@ public:
     {
         if (command < 0 || command >= (int8)m_handlerTable.size())
         {
-            LOG(logLevelError,
-                "Invalid (or unsupported) command: %x.", (0xFF&command));
-
-            if(pvAccessIsLoggable(logLevelError)) {
-                std::cerr<<"Invalid PVA header "<<hex<<(int)(0xFF&command)
-                         <<", its payload buffer\n"
-                         <<HexDump(*payloadBuffer, payloadSize);
+            if(IS_LOGGABLE(logLevelError)) {
+                std::cerr<<"Invalid (or unsupported) command: "<<std::hex<<(int)(0xFF&command)<<"\n"
+                         <<HexDump(*payloadBuffer, payloadSize).limit(256u);
             }
             return;
         }

--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -158,10 +158,9 @@ void ServerResponseHandler::handleResponse(osiSockAddr* responseFrom,
         LOG(logLevelError,
             "Invalid (or unsupported) command: %x.", (0xFF&command));
 
-        if(pvAccessIsLoggable(logLevelError)) {
-            std::cerr<<"Invalid PVA header "<<hex<<(int)(0xFF&command)
-                     <<", its payload buffer\n"
-                     <<HexDump(*payloadBuffer, payloadSize);
+        if(IS_LOGGABLE(logLevelError)) {
+            std::cerr<<"Invalid (or unsupported) command: "<<std::hex<<(int)(0xFF&command)<<"\n"
+                     <<HexDump(*payloadBuffer, payloadSize).limit(256u);
         }
         return;
     }

--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -155,16 +155,14 @@ void ServerResponseHandler::handleResponse(osiSockAddr* responseFrom,
 {
     if(command<0||command>=(int8)m_handlerTable.size())
     {
-        LOG(logLevelDebug,
+        LOG(logLevelError,
             "Invalid (or unsupported) command: %x.", (0xFF&command));
 
-        // TODO remove debug output
-        std::ostringstream name;
-        name<<"Invalid PVA header "<<hex<<(int)(0xFF&command);
-        name<<", its payload buffer";
-
-        hexDump(name.str(), (const int8*)payloadBuffer->getArray(),
-                payloadBuffer->getPosition(), payloadSize);
+        if(pvAccessIsLoggable(logLevelError)) {
+            std::cerr<<"Invalid PVA header "<<hex<<(int)(0xFF&command)
+                     <<", its payload buffer\n"
+                     <<HexDump(*payloadBuffer, payloadSize);
+        }
         return;
     }
 

--- a/src/utils/pv/hexDump.h
+++ b/src/utils/pv/hexDump.h
@@ -7,6 +7,8 @@
 #ifndef HEXDUMP_H_
 #define HEXDUMP_H_
 
+#include <ostream>
+
 #ifdef epicsExportSharedSymbols
 #   define hexDumpEpicsExportSharedSymbols
 #   undef epicsExportSharedSymbols
@@ -22,35 +24,34 @@
 #include <shareLib.h>
 
 namespace epics {
+namespace pvData {
+class ByteBuffer;
+}
 namespace pvAccess {
 
-/**
- * Output a buffer in hex format.
- * @param name  name (description) of the message.
- * @param bs    buffer to dump
- * @param len   first bytes (length) to dump.
- */
-epicsShareFunc void hexDump(std::string const & name, const epics::pvData::int8 *bs, int len);
+class epicsShareClass HexDump {
+    const char* buf;
+    size_t buflen;
+    size_t _limit;
+    unsigned _groupBy;
+    unsigned _perLine;
+public:
+    HexDump(const char* buf, size_t len);
+    explicit HexDump(const pvData::ByteBuffer& buf, size_t size=(size_t)-1, size_t offset=0u);
+    ~HexDump();
 
-/**
- * Output a buffer in hex format.
- * @param[in] name  name (description) of the message.
- * @param[in] bs    buffer to dump
- * @param[in] start dump message using given offset.
- * @param[in] len   first bytes (length) to dump.
- */
-epicsShareFunc void hexDump(std::string const & name, const epics::pvData::int8 *bs, int start, int len);
+    //! safety limit on max bytes printed
+    inline HexDump& limit(size_t n=(size_t)-1)        { _limit = n; return *this; }
+    //! insert a space after this many bytes
+    inline HexDump& bytesPerGroup(size_t n=(size_t)-1) { _groupBy = n; return *this; }
+    //! start a new line after this many bytes
+    inline HexDump& bytesPerLine(size_t n=(size_t)-1) { _perLine = n; return *this; }
 
-/**
- * Output a buffer in hex format.
- * @param[in] prologue string to prefixed to debug output, can be <code>null</code>
- * @param[in] name  name (description) of the message.
- * @param[in] bs    buffer to dump
- * @param[in] start dump message using given offset.
- * @param[in] len   first bytes (length) to dump.
- */
-epicsShareFunc void hexDump(std::string const & prologue, std::string const & name,
-                            const epics::pvData::int8 *bs, int start, int len);
+    friend std::ostream& operator<<(std::ostream& strm, const HexDump& hex);
+};
+
+epicsShareFunc
+std::ostream& operator<<(std::ostream& strm, const HexDump& hex);
 
 }
 }

--- a/testApp/utils/testHexDump.cpp
+++ b/testApp/utils/testHexDump.cpp
@@ -1,6 +1,9 @@
-#include <epicsUnitTest.h>
+
+#include <sstream>
+
 #include <testMain.h>
 
+#include <pv/pvUnitTest.h>
 #include <pv/hexDump.h>
 
 using namespace epics::pvData;
@@ -8,19 +11,16 @@ using namespace epics::pvAccess;
 
 MAIN(testHexDump)
 {
-    testPlan(3);
+    testPlan(1);
     testDiag("Tests for hexDump");
 
-    char TO_DUMP[] = "pvAccess dump test\0\1\2\3\4\5\6\254\255\256";
+    char TO_DUMP[] = "pvAccess dump test\0\1\2\3\4\5\6\xfd\xfe\xff";
 
-    hexDump("test", (int8*)TO_DUMP, 18+9);
-    testPass("Entire array");
+    std::ostringstream msg;
+    msg<<HexDump(TO_DUMP, sizeof(TO_DUMP)-1);
 
-    hexDump("only text", (int8*)TO_DUMP, 18);
-    testPass("Only text");
-
-    hexDump("22 byte test", (int8*)TO_DUMP, 22);
-    testPass("22 bytes test");
+    testEqual(msg.str(), "0x00 70764163 63657373 2064756d 70207465\n"
+                         "0x10 73740001 02030405 06fdfeff\n");
 
     return testDone();
 }


### PR DESCRIPTION
Begin ignoring old version 0 peers.  Current version is 1 since 2014.  cf. #137

Also clean up debug printing of invalid messages.