### PR TITLE
TX/RX Stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,3 @@ env:
   - BRBASE=7.0 RTEMS=4.9 TEST=NO
   - BRBASE=3.16
   - BRBASE=3.15
-  - BRBASE=3.14

--- a/src/client/pv/pvAccess.h
+++ b/src/client/pv/pvAccess.h
@@ -148,6 +148,31 @@ class ChannelPutRequester;
 class ChannelPutGetRequester;
 class ChannelRPCRequester;
 
+/** @brief Expose statistics related to network transport
+ *
+ * Various sub-classes of ChannelBaseRequester (for servers) or ChannelRequest (for clients)
+ * may by dynamic_cast<>able to NetStats.
+ */
+struct epicsShareClass NetStats {
+    struct Counter {
+        size_t tx, rx;
+
+        inline Counter() :tx(0u), rx(0u) {}
+    };
+    struct Stats {
+        std::string transportPeer;
+        Counter transportBytes;
+        Counter operationBytes;
+        bool populated;
+
+        inline Stats() :populated(false) {}
+    };
+
+    virtual ~NetStats();
+    //! Query current counter values
+    virtual void stats(Stats& s) const =0;
+};
+
 //! Base for all Requesters (callbacks to client)
 struct epicsShareClass ChannelBaseRequester : virtual public epics::pvData::Requester
 {

--- a/src/client/pvAccess.cpp
+++ b/src/client/pvAccess.cpp
@@ -384,6 +384,8 @@ ChannelProvider::~ChannelProvider()
     REFTRACE_DECREMENT(num_instances);
 }
 
+NetStats::~NetStats() {}
+
 size_t ChannelBaseRequester::num_instances;
 
 ChannelBaseRequester::ChannelBaseRequester()

--- a/src/remote/pv/codec.h
+++ b/src/remote/pv/codec.h
@@ -260,7 +260,6 @@ protected:
     int8_t _command;
     int32_t _payloadSize; // TODO why not size_t?
     epics::pvData::int32 _remoteTransportSocketReceiveBufferSize;
-    int64_t _totalBytesSent;
     //TODO initialize union
     osiSockAddr _sendTo;
     epicsThreadId _senderThread;

--- a/src/remote/pv/remote.h
+++ b/src/remote/pv/remote.h
@@ -138,6 +138,7 @@ class TransportSender : public Lockable, public fair_queue<TransportSender>::ent
 public:
     POINTER_DEFINITIONS(TransportSender);
 
+    TransportSender() :bytesTX(0u), bytesRX(0u) {}
     virtual ~TransportSender() {}
 
     /**
@@ -149,6 +150,9 @@ public:
      * NOTE: these limitations allow efficient implementation.
      */
     virtual void send(epics::pvData::ByteBuffer* buffer, TransportSendControl* control) = 0;
+
+    size_t bytesTX;
+    size_t bytesRX;
 };
 
 class ClientChannelImpl;
@@ -264,6 +268,9 @@ public:
      * @param data the data (any data), can be <code>null</code>.
      */
     virtual void authNZMessage(epics::pvData::PVStructure::shared_pointer const & data) = 0;
+
+    size_t _totalBytesSent;
+    size_t _totalBytesRecv;
 };
 
 class Channel;
@@ -341,7 +348,7 @@ protected:
  * A request that expects an response.
  * Responses identified by its I/O ID.
  */
-class ResponseRequest {
+class ResponseRequest : public TransportSender {
 public:
     POINTER_DEFINITIONS(ResponseRequest);
 

--- a/src/server/baseChannelRequester.cpp
+++ b/src/server/baseChannelRequester.cpp
@@ -4,6 +4,8 @@
  * in file LICENSE that is included with this distribution.
  */
 
+#include <epicsAtomic.h>
+
 #define epicsExportSharedSymbols
 #include <pv/baseChannelRequester.h>
 
@@ -83,6 +85,16 @@ void BaseChannelRequester::sendFailureMessage(const int8 command, Transport::sha
 {
     TransportSender::shared_pointer sender(new BaseChannelRequesterFailureMessageTransportSender(command, transport, ioid, qos, status));
     transport->enqueueSendRequest(sender);
+}
+
+void BaseChannelRequester::stats(Stats &s) const
+{
+    s.populated = true;
+    s.operationBytes.tx = atomic::get(bytesTX);
+    s.operationBytes.rx = atomic::get(bytesRX);
+    s.transportBytes.tx = atomic::get(_transport->_totalBytesSent);
+    s.transportBytes.rx = atomic::get(_transport->_totalBytesRecv);
+    s.transportPeer = _transport->getRemoteName();
 }
 
 BaseChannelRequesterMessageTransportSender::BaseChannelRequesterMessageTransportSender(const pvAccessID ioid, const string message,const epics::pvData::MessageType messageType):

--- a/src/server/pv/baseChannelRequester.h
+++ b/src/server/pv/baseChannelRequester.h
@@ -18,7 +18,11 @@ namespace pvAccess {
 class ServerChannel;
 class ChannelRequest;
 
-class BaseChannelRequester :  virtual public epics::pvData::Requester, public Destroyable
+class BaseChannelRequester :
+        virtual public epics::pvData::Requester,
+        public TransportSender,
+        public NetStats,
+        public Destroyable
 {
 public:
     POINTER_DEFINITIONS(BaseChannelRequester);
@@ -35,6 +39,8 @@ public:
     virtual void message(std::string const & message, epics::pvData::MessageType messageType) OVERRIDE FINAL;
     static void message(Transport::shared_pointer const & transport, const pvAccessID ioid, const std::string message, const epics::pvData::MessageType messageType);
     static void sendFailureMessage(const epics::pvData::int8 command, Transport::shared_pointer const & transport, const pvAccessID ioid, const epics::pvData::int8 qos, const epics::pvData::Status status);
+
+    virtual void stats(Stats &s) const OVERRIDE FINAL;
 
     static const epics::pvData::Status okStatus;
     static const epics::pvData::Status badCIDStatus;

--- a/src/server/pv/responseHandlers.h
+++ b/src/server/pv/responseHandlers.h
@@ -286,7 +286,6 @@ public:
 class ServerChannelGetRequesterImpl :
     public BaseChannelRequester,
     public ChannelGetRequester,
-    public TransportSender,
     public std::tr1::enable_shared_from_this<ServerChannelGetRequesterImpl>
 {
 public:
@@ -343,7 +342,6 @@ public:
 class ServerChannelPutRequesterImpl :
     public BaseChannelRequester,
     public ChannelPutRequester,
-    public TransportSender,
     public std::tr1::enable_shared_from_this<ServerChannelPutRequesterImpl>
 {
 public:
@@ -402,7 +400,6 @@ public:
 class ServerChannelPutGetRequesterImpl :
     public BaseChannelRequester,
     public ChannelPutGetRequester,
-    public TransportSender,
     public std::tr1::enable_shared_from_this<ServerChannelPutGetRequesterImpl>
 {
 public:
@@ -472,7 +469,6 @@ public:
 class ServerMonitorRequesterImpl :
     public BaseChannelRequester,
     public MonitorRequester,
-    public TransportSender,
     public std::tr1::enable_shared_from_this<ServerMonitorRequesterImpl>
 {
 public:
@@ -538,7 +534,6 @@ public:
 class ServerChannelArrayRequesterImpl :
     public BaseChannelRequester,
     public ChannelArrayRequester,
-    public TransportSender,
     public std::tr1::enable_shared_from_this<ServerChannelArrayRequesterImpl>
 {
 public:
@@ -647,7 +642,6 @@ public:
 class ServerChannelProcessRequesterImpl :
     public BaseChannelRequester,
     public ChannelProcessRequester,
-    public TransportSender,
     public std::tr1::enable_shared_from_this<ServerChannelProcessRequesterImpl>
 {
 public:
@@ -701,7 +695,6 @@ private:
 class ServerGetFieldRequesterImpl :
     public BaseChannelRequester,
     public GetFieldRequester,
-    public TransportSender,
     public std::tr1::enable_shared_from_this<ServerGetFieldRequesterImpl>
 {
 public:
@@ -766,7 +759,6 @@ public:
 class ServerChannelRPCRequesterImpl :
     public BaseChannelRequester,
     public ChannelRPCRequester,
-    public TransportSender,
     public std::tr1::enable_shared_from_this<ServerChannelRPCRequesterImpl>
 {
 public:

--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -24,6 +24,7 @@
 #include <osiSock.h>
 #include <osiProcess.h>
 #include <epicsAssert.h>
+#include <epicsAtomic.h>
 
 #include <pv/byteBuffer.h>
 #include <pv/timer.h>
@@ -1048,6 +1049,7 @@ void ServerGetHandler::handleResponse(osiSockAddr* responseFrom,
             BaseChannelRequester::sendFailureMessage((int8)CMD_GET, transport, ioid, qosCode, BaseChannelRequester::badIOIDStatus);
             return;
         }
+        atomic::add(request->bytesRX, payloadSize);
 
         if (!request->startRequest(qosCode))
         {
@@ -1284,6 +1286,7 @@ void ServerPutHandler::handleResponse(osiSockAddr* responseFrom,
             BaseChannelRequester::sendFailureMessage((int8)CMD_PUT, transport, ioid, qosCode, BaseChannelRequester::badIOIDStatus);
             return;
         }
+        atomic::add(request->bytesRX, payloadSize);
 
         if (!request->startRequest(qosCode))
         {
@@ -1523,6 +1526,7 @@ void ServerPutGetHandler::handleResponse(osiSockAddr* responseFrom,
             BaseChannelRequester::sendFailureMessage((int8)CMD_PUT_GET, transport, ioid, qosCode, BaseChannelRequester::badIOIDStatus);
             return;
         }
+        atomic::add(request->bytesRX, payloadSize);
 
         if (!request->startRequest(qosCode))
         {
@@ -1817,6 +1821,7 @@ void ServerMonitorHandler::handleResponse(osiSockAddr* responseFrom,
             BaseChannelRequester::sendFailureMessage((int8)CMD_MONITOR, transport, ioid, qosCode, BaseChannelRequester::badIOIDStatus);
             return;
         }
+        atomic::add(request->bytesRX, payloadSize);
 
         if (ack)
         {
@@ -2150,6 +2155,7 @@ void ServerArrayHandler::handleResponse(osiSockAddr* responseFrom,
             BaseChannelRequester::sendFailureMessage((int8)CMD_ARRAY, transport, ioid, qosCode, BaseChannelRequester::badIOIDStatus);
             return;
         }
+        atomic::add(request->bytesRX, payloadSize);
 
         if (!request->startRequest(qosCode))
         {
@@ -2411,6 +2417,7 @@ void ServerDestroyRequestHandler::handleResponse(osiSockAddr* responseFrom,
         failureResponse(transport, ioid, BaseChannelRequester::badIOIDStatus);
         return;
     }
+    // atomic::add(request->bytesRX, payloadSize);
 
     // destroy
     request->destroy();
@@ -2451,6 +2458,7 @@ void ServerCancelRequestHandler::handleResponse(osiSockAddr* responseFrom,
         failureResponse(transport, ioid, BaseChannelRequester::badIOIDStatus);
         return;
     }
+    //atomic::add(request->bytesRX, payloadSize);
 
     ChannelRequest::shared_pointer cr = dynamic_pointer_cast<ChannelRequest>(request->getOperation());
     if (!cr)
@@ -2510,6 +2518,7 @@ void ServerProcessHandler::handleResponse(osiSockAddr* responseFrom,
             BaseChannelRequester::sendFailureMessage((int8)CMD_PROCESS, transport, ioid, qosCode, BaseChannelRequester::badIOIDStatus);
             return;
         }
+        atomic::add(request->bytesRX, payloadSize);
 
         if (!request->startRequest(qosCode))
         {
@@ -2750,6 +2759,7 @@ void ServerRPCHandler::handleResponse(osiSockAddr* responseFrom,
             BaseChannelRequester::sendFailureMessage((int8)CMD_RPC, transport, ioid, qosCode, BaseChannelRequester::badIOIDStatus);
             return;
         }
+        atomic::add(request->bytesRX, payloadSize);
 
         if (!request->startRequest(qosCode))
         {


### PR DESCRIPTION
Keep and expose statistics on number of bytes sent/received per socket, and per operation.

Will be used by the PVA gateway to track client bandwidth utilization.

The new `struct NetStats` is not placed in the public portion of the ChannelProvider class hierarchy as it will not be implemented by many providers (probably only the PVA client and server).  It does not fit with the symmetric idea of ChannelProvider.  eg. It is implemented by PVA client for `class ChannelGet`, but for `class ChannelGetRequester` by PVA server.