### PR TITLE
Tweak pvlist output to make it easier to cut/paste

### DIFF
--- a/pvtoolsSrc/pvlist.cpp
+++ b/pvtoolsSrc/pvlist.cpp
@@ -611,16 +611,16 @@ int main (int argc, char *argv[])
             const ServerEntry& entry = iter->second;
 
             cout << "GUID 0x" << entry.guid << " version " << (int)entry.version << ": "
-                 << entry.protocol << "@[";
+                 << entry.protocol << "@[ ";
 
             size_t count = entry.addresses.size();
             for (size_t i = 0; i < count; i++)
             {
                 cout << inetAddressToString(entry.addresses[i]);
                 if (i < (count-1))
-                    cout << ", ";
+                    cout << " ";
             }
-            cout << ']' << endl;
+            cout << " ]" << endl;
         }
     }
     else


### PR DESCRIPTION
Prior syntax had no spaces around ip_addr:port which results in tcp@[ and ] getting 
picked up w/ mouse based word selection.
Old syntax:
GUID 0x0863D45C00000000B8AAFA06 version 1: tcp@[172.21.68.76:47626]
New syntax:
GUID 0x0863D45C00000000B8AAFA06 version 1: tcp@[ 172.21.68.76:47626 ]
