### PR TITLE
Cleanup whitespace

### DIFF
--- a/pvtoolsSrc/pvlist.cpp
+++ b/pvtoolsSrc/pvlist.cpp
@@ -87,7 +87,7 @@ std::size_t readSize(ByteBuffer* buffer) {
 string deserializeString(ByteBuffer* buffer) {
 
     std::size_t size = /*SerializeHelper::*/readSize(buffer);
-    if(size!=(size_t)-1)	// TODO null strings check, to be removed in the future
+    if(size!=(size_t)-1)    // TODO null strings check, to be removed in the future
     {
         // entire string is in buffer, simply create a string out of it (copy)
         std::size_t pos = buffer->getPosition();
@@ -339,8 +339,8 @@ bool discoverServers(double timeOut)
     sendBuffer.putByte(PVA_MAGIC);
     sendBuffer.putByte(PVA_CLIENT_PROTOCOL_REVISION);
     sendBuffer.putByte((EPICS_BYTE_ORDER == EPICS_ENDIAN_BIG) ? 0x80 : 0x00); // data + 7-bit endianess
-    sendBuffer.putByte((int8_t)CMD_SEARCH);	// search
-    sendBuffer.putInt(4+1+3+16+2+1+2);		// "zero" payload
+    sendBuffer.putByte((int8_t)CMD_SEARCH); // search
+    sendBuffer.putInt(4+1+3+16+2+1+2);      // "zero" payload
 
     sendBuffer.putInt(0);   // sequenceId
     sendBuffer.putByte((int8_t)0x81);    // reply required // TODO unicast vs multicast; for now we mark ourselves as unicast
@@ -351,8 +351,8 @@ bool discoverServers(double timeOut)
     encodeAsIPv6Address(&sendBuffer, &responseAddress);
     sendBuffer.putShort((int16_t)ntohs(responseAddress.ia.sin_port));
 
-    sendBuffer.putByte((int8_t)0x00);	// protocol count
-    sendBuffer.putShort((int16_t)0);	// name count
+    sendBuffer.putByte((int8_t)0x00);   // protocol count
+    sendBuffer.putShort((int16_t)0);    // name count
 
     bool oneOK = false;
     for (size_t i = 0; i < broadcastAddresses.size(); i++)
@@ -503,16 +503,16 @@ void usage (void)
 
 /*+**************************************************************************
  *
- * Function:	main
+ * Function:    main
  *
- * Description:	pvlist main()
- * 		Evaluate command line options, ...
+ * Description: pvlist main()
+ *              Evaluate command line options, ...
  *
- * Arg(s) In:	[options] [<server>]...
+ * Arg(s) In:   [options] [<server>]...
  *
- * Arg(s) Out:	none
+ * Arg(s) Out:  none
  *
- * Return(s):	Standard return code (0=success, 1=error)
+ * Return(s):   Standard return code (0=success, 1=error)
  *
  **************************************************************************-*/
 

--- a/src/ca/caChannel.cpp
+++ b/src/ca/caChannel.cpp
@@ -162,7 +162,7 @@ void CAChannel::activate(short priority)
 CAChannel::~CAChannel()
 {
     if(DEBUG_LEVEL>0) {
-        cout << "CAChannel::~CAChannel() " << channelName 
+        cout << "CAChannel::~CAChannel() " << channelName
              << " channelCreated " << (channelCreated ? "true" : "false")
              << endl;
     }
@@ -177,7 +177,7 @@ void CAChannel::disconnectChannel()
 {
     if(DEBUG_LEVEL>0) {
         cout << "CAChannel::disconnectChannel() "
-             << channelName 
+             << channelName
              << " channelCreated " << (channelCreated ? "true" : "false")
              << endl;
     }
@@ -285,7 +285,7 @@ ChannelGet::shared_pointer CAChannel::createChannelGet(
     if(DEBUG_LEVEL>0) {
         cout << "CAChannel::createChannelGet " << channelName << endl;
     }
-    CAChannelGetPtr channelGet = 
+    CAChannelGetPtr channelGet =
         CAChannelGet::create(shared_from_this(), channelGetRequester, pvRequest);
     {
          Lock lock(requestsMutex);
@@ -306,7 +306,7 @@ ChannelPut::shared_pointer CAChannel::createChannelPut(
     if(DEBUG_LEVEL>0) {
         cout << "CAChannel::createChannelPut " << channelName << endl;
     }
-    CAChannelPutPtr channelPut = 
+    CAChannelPutPtr channelPut =
         CAChannelPut::create(shared_from_this(), channelPutRequester, pvRequest);
     {
          Lock lock(requestsMutex);
@@ -327,7 +327,7 @@ Monitor::shared_pointer CAChannel::createMonitor(
     if(DEBUG_LEVEL>0) {
         cout << "CAChannel::createMonitor " << channelName << endl;
     }
-    CAChannelMonitorPtr channelMonitor = 
+    CAChannelMonitorPtr channelMonitor =
         CAChannelMonitor::create(shared_from_this(), monitorRequester, pvRequest);
     {
          Lock lock(requestsMutex);
@@ -496,10 +496,10 @@ static void ca_get_handler(struct event_handler_args args)
 void CAChannelGet::getDone(struct event_handler_args &args)
 {
     if(DEBUG_LEVEL>1) {
-        std::cout << "CAChannelGet::getDone " 
+        std::cout << "CAChannelGet::getDone "
             <<  channel->getChannelName() << endl;
     }
-    
+
     ChannelGetRequester::shared_pointer getRequester(channelGetRequester.lock());
     if(!getRequester) return;
     getStatus = dbdToPv->getFromDBD(pvStructure,bitSet,args);
@@ -640,7 +640,7 @@ void CAChannelPut::put(PVStructure::shared_pointer const & pvPutStructure,
     ChannelPutRequester::shared_pointer putRequester(channelPutRequester.lock());
     if(!putRequester) return;
     {
-       Lock lock(mutex);    
+       Lock lock(mutex);
        isPut = true;
     }
     putStatus = dbdToPv->putToDBD(channel,pvPutStructure,block,&ca_put_handler,this);
@@ -671,7 +671,7 @@ void CAChannelPut::getDone(struct event_handler_args &args)
      if(DEBUG_LEVEL>1) {
         cout << "CAChannelPut::getDone " << channel->getChannelName() << endl;
     }
-    
+
     ChannelPutRequester::shared_pointer putRequester(channelPutRequester.lock());
     if(!putRequester) return;
     getStatus = dbdToPv->getFromDBD(pvStructure,bitSet,args);
@@ -698,7 +698,7 @@ void CAChannelPut::get()
     ChannelPutRequester::shared_pointer putRequester(channelPutRequester.lock());
     if(!putRequester) return;
     {
-       Lock lock(mutex);    
+       Lock lock(mutex);
        isPut = false;
     }
 
@@ -753,7 +753,7 @@ private:
     size_t queueSize;
     bool isStarted;
     Mutex mutex;
-    
+
     std::queue<MonitorElementPtr> monitorElementQueue;
 public:
     CACMonitorQueue(
@@ -763,7 +763,7 @@ public:
      {}
      ~CACMonitorQueue()
      {
-     } 
+     }
      void start()
      {
          Lock guard(mutex);
@@ -784,7 +784,7 @@ public:
          Lock guard(mutex);
          if(!isStarted) return false;
          if(monitorElementQueue.size()==queueSize) return false;
-         PVStructure::shared_pointer pvs = 
+         PVStructure::shared_pointer pvs =
               getPVDataCreate()->createPVStructure(pvStructure);
          MonitorElementPtr monitorElement(new MonitorElement(pvs));
          *(monitorElement->changedBitSet) = *(activeElement->changedBitSet);
@@ -826,7 +826,7 @@ CAChannelMonitorPtr CAChannelMonitor::create(
 CAChannelMonitor::CAChannelMonitor(
     CAChannel::shared_pointer const & channel,
     MonitorRequester::shared_pointer const & monitorRequester,
-    PVStructurePtr const & pvRequest) 
+    PVStructurePtr const & pvRequest)
 :
     channel(channel),
     monitorRequester(monitorRequester),
@@ -896,7 +896,7 @@ void CAChannelMonitor::subscriptionEvent(struct event_handler_args &args)
              << channel->getChannelName() << endl;
     }
     {
-       Lock lock(mutex);    
+       Lock lock(mutex);
        if(!isStarted) return;
     }
     MonitorRequester::shared_pointer requester(monitorRequester.lock());
@@ -975,7 +975,7 @@ Status CAChannelMonitor::stop()
     {
          Lock lock(mutex);
          if(!isStarted) return Status(Status::STATUSTYPE_WARNING,"already stopped");
-         isStarted = false;     
+         isStarted = false;
     }
     monitorQueue->stop();
     int result = ca_clear_subscription(pevid);

--- a/src/ca/caProvider.cpp
+++ b/src/ca/caProvider.cpp
@@ -32,7 +32,7 @@ using namespace epics::pvData;
         catch (std::exception &e) { LOG(logLevelError, "Unhandled exception caught from client code at %s:%d: %s", __FILE__, __LINE__, e.what()); } \
                 catch (...) { LOG(logLevelError, "Unhandled exception caught from client code at %s:%d.", __FILE__, __LINE__); }
 
-CAChannelProvider::CAChannelProvider() 
+CAChannelProvider::CAChannelProvider()
     : current_context(0)
 {
     initialize();
@@ -73,7 +73,7 @@ CAChannelProvider::~CAChannelProvider()
            std::cout << "~CAChannelProvider() calling disconnectChannel "
                      << channelQ.front()->getChannelName()
                       << std::endl;
-       }  
+       }
        channelQ.front()->disconnectChannel();
        channelQ.pop();
     }
@@ -218,4 +218,3 @@ void CAClientFactory::stop()
 }
 
 }}}
-

--- a/src/ca/channelConnectThread.cpp
+++ b/src/ca/channelConnectThread.cpp
@@ -50,7 +50,7 @@ void ChannelConnectThread::start()
         "channelConnectThread",
         epicsThreadGetStackSize(epicsThreadStackSmall),
         epicsThreadPriorityLow));
-    thread->start(); 
+    thread->start();
 }
 
 
@@ -67,7 +67,7 @@ void ChannelConnectThread::stop()
 void ChannelConnectThread::channelConnected(
     NotifyChannelRequesterPtr const &notifyChannelRequester)
 {
-    {   
+    {
         Lock lock(mutex);
         if(notifyChannelRequester->isOnQueue) return;
         notifyChannelRequester->isOnQueue = true;

--- a/src/ca/dbdToPv.cpp
+++ b/src/ca/dbdToPv.cpp
@@ -147,7 +147,7 @@ void DbdToPv::activate(
         string mess(caChannel->getChannelName());
             mess += " DbdToPv::activate pvRequest is null";
             throw  std::runtime_error(mess);
-    } 
+    }
     PVStructurePtr fieldPVStructure;
     if(pvRequest->getPVFields().size()==0) {
          fieldPVStructure = pvRequest;
@@ -159,8 +159,8 @@ void DbdToPv::activate(
         mess << caChannel->getChannelName()
           << " DbdToPv::activate illegal pvRequest " << pvRequest;
         throw std::runtime_error(mess.str());
-    } 
-    if(fieldPVStructure->getPVFields().size()==0) 
+    }
+    if(fieldPVStructure->getPVFields().size()==0)
     {
         valueRequested = true;
         alarmRequested = true;
@@ -308,7 +308,7 @@ void DbdToPv::activate(
     caRequestType = caValueType;
     if(displayRequested || controlRequested || valueAlarmRequested)
     {
-       caRequestType = dbf_type_to_DBR_CTRL(caValueType); 
+       caRequestType = dbf_type_to_DBR_CTRL(caValueType);
     } else if(timeStampRequested || alarmRequested) {
        caRequestType = dbf_type_to_DBR_TIME(caValueType);
     } else {
@@ -350,7 +350,7 @@ void DbdToPv::getChoicesDone(struct event_handler_args &args)
     choices.reserve(num);
     for(size_t i=0; i<num; ++i) choices.push_back(string(&dbr_enum_p->strs[i][0]));
     choicesEvent.signal();
-} 
+}
 
 
 void DbdToPv::getChoices(CAChannelPtr const & caChannel)
@@ -522,7 +522,7 @@ Status DbdToPv::getFromDBD(
                      ConvertPtr convert = getConvert();
                      size_t n = choices.size();
                      pvChoices->setLength(n);
-                     convert->fromStringArray(pvChoices,0,n,choices,0);       
+                     convert->fromStringArray(pvChoices,0,n,choices,0);
                      bitSet->set(pvStructure->getSubField("value")->getFieldOffset());
                 } else {
                      bitSet->set(value->getFieldOffset());
@@ -552,7 +552,7 @@ Status DbdToPv::getFromDBD(
                 }
                 copy_DBRScalar<dbr_long_t,PVInt>(value,pvValue); break;
            case DBR_FLOAT: copy_DBRScalar<dbr_float_t,PVFloat>(value,pvValue); break;
-           case DBR_DOUBLE: 
+           case DBR_DOUBLE:
                 if(dbfIsINT64)
                 {
                    copy_DBRScalar<dbr_double_t,PVLong>(value,pvValue);
@@ -575,7 +575,7 @@ Status DbdToPv::getFromDBD(
        }
     }
     if(alarmRequested) {
-        // Note that status and severity are aways the first two members of DBR_ 
+        // Note that status and severity are aways the first two members of DBR_
         const dbr_sts_string *data = static_cast<const dbr_sts_string *>(args.dbr);
         dbr_short_t status = data->status;
         dbr_short_t severity = data->severity;
@@ -927,21 +927,21 @@ Status DbdToPv::putToDBD(
                break;
            }
            case DBR_STRING: pValue = pvStructure->getSubField<PVString>("value")->get().c_str(); break;
-           case DBR_CHAR: 
+           case DBR_CHAR:
                if(dbfIsUCHAR)
                {
                     pValue = put_DBRScalar<dbr_char_t,PVUByte>(&bvalue,pvValue);
                     break;
                }
                pValue = put_DBRScalar<dbr_char_t,PVByte>(&bvalue,pvValue); break;
-           case DBR_SHORT: 
+           case DBR_SHORT:
                if(dbfIsUSHORT)
                {
                     pValue = put_DBRScalar<dbr_short_t,PVUShort>(&svalue,pvValue);
                     break;
                }
                pValue = put_DBRScalar<dbr_short_t,PVShort>(&svalue,pvValue); break;
-           case DBR_LONG: 
+           case DBR_LONG:
                if(dbfIsULONG)
                {
                     pValue = put_DBRScalar<dbr_long_t,PVUInt>(&lvalue,pvValue);
@@ -949,7 +949,7 @@ Status DbdToPv::putToDBD(
                }
                pValue = put_DBRScalar<dbr_long_t,PVInt>(&lvalue,pvValue); break;
            case DBR_FLOAT: pValue = put_DBRScalar<dbr_float_t,PVFloat>(&fvalue,pvValue); break;
-           case DBR_DOUBLE: 
+           case DBR_DOUBLE:
                if(dbfIsINT64)
                {
                     pValue = put_DBRScalar<dbr_double_t,PVLong>(&dvalue,pvValue);
@@ -982,6 +982,6 @@ Status DbdToPv::putToDBD(
     }
     if(ca_stringBuffer!=NULL) delete[] ca_stringBuffer;
     return status;
-}    
+}
 
 }}}

--- a/src/ca/dbdToPv.h
+++ b/src/ca/dbdToPv.h
@@ -35,8 +35,8 @@ typedef std::tr1::shared_ptr<ValueAlarmDbd> ValueAlarmDbdPtr;
 
 struct CaAlarm
 {
-    dbr_short_t	status;
-    dbr_short_t	severity;
+    dbr_short_t status;
+    dbr_short_t severity;
     CaAlarm() : status(0), severity(0) {}
 };
 
@@ -58,7 +58,7 @@ struct CaControl
 
 struct CaValueAlarm
 {
-    double upper_alarm_limit;	
+    double upper_alarm_limit;   
     double upper_warning_limit;
     double lower_warning_limit;
     double lower_alarm_limit;

--- a/src/ca/getDoneThread.cpp
+++ b/src/ca/getDoneThread.cpp
@@ -50,7 +50,7 @@ void GetDoneThread::start()
         "getDoneThread",
         epicsThreadGetStackSize(epicsThreadStackBig),
         epicsThreadPriorityLow));
-    thread->start(); 
+    thread->start();
 }
 
 
@@ -66,7 +66,7 @@ void GetDoneThread::stop()
 
 void GetDoneThread::getDone(NotifyGetRequesterPtr const &notifyGetRequester)
 {
-    {   
+    {
         Lock lock(mutex);
         if(notifyGetRequester->isOnQueue) return;
         notifyGetRequester->isOnQueue = true;

--- a/src/ca/monitorEventThread.cpp
+++ b/src/ca/monitorEventThread.cpp
@@ -49,7 +49,7 @@ void MonitorEventThread::start()
         "monitorEventThread",
         epicsThreadGetStackSize(epicsThreadStackBig),
         epicsThreadPriorityLow));
-    thread->start();  
+    thread->start();
 }
 
 void MonitorEventThread::stop()
@@ -65,7 +65,7 @@ void MonitorEventThread::stop()
 
 void MonitorEventThread::event(NotifyMonitorRequesterPtr const &notifyMonitorRequester)
 {
-    {   
+    {
         Lock lock(mutex);
         if(notifyMonitorRequester->isOnQueue) return;
         notifyMonitorRequester->isOnQueue = true;

--- a/src/ca/putDoneThread.cpp
+++ b/src/ca/putDoneThread.cpp
@@ -50,7 +50,7 @@ void PutDoneThread::start()
         "putDoneThread",
         epicsThreadGetStackSize(epicsThreadStackBig),
         epicsThreadPriorityLow));
-    thread->start(); 
+    thread->start();
 }
 
 
@@ -66,7 +66,7 @@ void PutDoneThread::stop()
 
 void PutDoneThread::putDone(NotifyPutRequesterPtr const &notifyPutRequester)
 {
-    {   
+    {
         Lock lock(mutex);
         if(notifyPutRequester->isOnQueue) return;
         notifyPutRequester->isOnQueue = true;

--- a/src/client/pv/monitor.h
+++ b/src/client/pv/monitor.h
@@ -26,7 +26,7 @@
 
 #ifdef monitorEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef monitorEpicsExportSharedSymbols
+#       undef monitorEpicsExportSharedSymbols
 #endif
 
 #include <pv/requester.h>

--- a/src/client/pv/pvAccess.h
+++ b/src/client/pv/pvAccess.h
@@ -22,7 +22,7 @@
 
 #ifdef pvAccessEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef pvAccessEpicsExportSharedSymbols
+#       undef pvAccessEpicsExportSharedSymbols
 #endif
 
 #include <pv/pvaVersion.h>

--- a/src/factory/ChannelAccessFactory.cpp
+++ b/src/factory/ChannelAccessFactory.cpp
@@ -267,4 +267,3 @@ ChannelProvider::createChannel(std::string const & name,
 
 }
 }
-

--- a/src/pipelineService/pv/pipelineServer.h
+++ b/src/pipelineService/pv/pipelineServer.h
@@ -16,7 +16,7 @@
 
 #ifdef pipelineServerEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef pipelineServerEpicsExportSharedSymbols
+#       undef pipelineServerEpicsExportSharedSymbols
 #endif
 
 #include <pv/pvAccess.h>

--- a/src/pipelineService/pv/pipelineService.h
+++ b/src/pipelineService/pv/pipelineService.h
@@ -19,7 +19,7 @@
 
 #ifdef pipelineServiceEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef pipelineServiceEpicsExportSharedSymbols
+#       undef pipelineServiceEpicsExportSharedSymbols
 #endif
 
 #include <pv/pvAccess.h>

--- a/src/pva/pv/pvaConstants.h
+++ b/src/pva/pv/pvaConstants.h
@@ -18,7 +18,7 @@
 
 #ifdef pvaConstantsepicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef pvaConstantsepicsExportSharedSymbols
+#       undef pvaConstantsepicsExportSharedSymbols
 #endif
 #include <shareLib.h>
 

--- a/src/pva/pv/pvaVersion.h
+++ b/src/pva/pv/pvaVersion.h
@@ -17,7 +17,7 @@
 
 #ifdef pvaVersionEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef pvaVersionEpicsExportSharedSymbols
+#       undef pvaVersionEpicsExportSharedSymbols
 #endif
 
 #include <shareLib.h>
@@ -38,12 +38,12 @@ class epicsShareClass Version {
 public:
     /**
      * Default constructor.
-     * @param productName	product name.
-     * @param implementationLangugage	implementation language.
-     * @param majorVersion	major version.
-     * @param minorVersion	minor version.
-     * @param maintenanceVersion	maintenance version.
-     * @param developmentFlag	development indicator flag.
+     * @param productName       product name.
+     * @param implementationLangugage   implementation language.
+     * @param majorVersion      major version.
+     * @param minorVersion      minor version.
+     * @param maintenanceVersion        maintenance version.
+     * @param developmentFlag   development indicator flag.
      */
     Version(std::string const & productName,
             std::string const & implementationLangugage,

--- a/src/remote/beaconHandler.cpp
+++ b/src/remote/beaconHandler.cpp
@@ -84,4 +84,3 @@ bool BeaconHandler::updateBeacon(int8 /*remoteTransportRevision*/, TimeStamp* /*
 
 }
 }
-

--- a/src/remote/channelSearchManager.cpp
+++ b/src/remote/channelSearchManager.cpp
@@ -392,4 +392,3 @@ void ChannelSearchManager::timerStopped()
 
 }
 }
-

--- a/src/remote/channelSearchManager.cpp
+++ b/src/remote/channelSearchManager.cpp
@@ -209,7 +209,7 @@ void ChannelSearchManager::initializeSendBuffer()
     m_sendBuffer.putByte(PVA_CLIENT_PROTOCOL_REVISION);
     m_sendBuffer.putByte((EPICS_BYTE_ORDER == EPICS_ENDIAN_BIG) ? 0x80 : 0x00); // data + 7-bit endianess
     m_sendBuffer.putByte(CMD_SEARCH);
-    m_sendBuffer.putInt(4+1+3+16+2+1);		// "zero" payload
+    m_sendBuffer.putInt(4+1+3+16+2+1);      // "zero" payload
     m_sendBuffer.putInt(m_sequenceNumber);
 
     // multicast vs unicast mask
@@ -230,7 +230,7 @@ void ChannelSearchManager::initializeSendBuffer()
 
     MockTransportSendControl control;
     SerializeHelper::serializeString("tcp", &m_sendBuffer, &control);
-    m_sendBuffer.putShort((int16_t)0);	// count
+    m_sendBuffer.putShort((int16_t)0);  // count
 }
 
 void ChannelSearchManager::flushSendBuffer()

--- a/src/remote/codec.cpp
+++ b/src/remote/codec.cpp
@@ -363,7 +363,7 @@ bool AbstractCodec::readToBuffer(
     }
 
     // assumption: remainingBytes < MAX_ENSURE_DATA_BUFFER_SIZE &&
-    //			   requiredBytes < (socketBuffer.capacity() - 1)
+    //             requiredBytes < (socketBuffer.capacity() - 1)
 
     //
     // copy unread part to the beginning of the buffer
@@ -427,7 +427,7 @@ void AbstractCodec::ensureData(std::size_t size) {
         return;
 
     // to large for buffer...
-    if (size > MAX_ENSURE_DATA_SIZE)	{// half for SPLIT, half for SEGMENTED
+    if (size > MAX_ENSURE_DATA_SIZE)    {// half for SPLIT, half for SEGMENTED
         std::ostringstream msg;
         msg << "requested for buffer size " << size
             << ", but maximum " << MAX_ENSURE_DATA_SIZE << " is allowed.";
@@ -471,7 +471,7 @@ void AbstractCodec::ensureData(std::size_t size) {
         {
             // TODO check flags
             //if (flags && SEGMENTED_FLAGS_MASK == 0)
-            //	throw IllegalStateException("segmented message expected,
+            //  throw IllegalStateException("segmented message expected,
             //but current message flag does not indicate it");
 
 
@@ -596,15 +596,15 @@ void AbstractCodec::startMessage(
     std::size_t ensureCapacity,
     epics::pvData::int32 payloadSize) {
     _lastMessageStartPosition =
-        std::numeric_limits<size_t>::max();		// TODO revise this
+        std::numeric_limits<size_t>::max();     // TODO revise this
     ensureBuffer(
         PVA_MESSAGE_HEADER_SIZE + ensureCapacity + _nextMessagePayloadOffset);
     _lastMessageStartPosition = _sendBuffer.getPosition();
     _sendBuffer.putByte(PVA_MAGIC);
     _sendBuffer.putByte(_clientServerFlag ? PVA_SERVER_PROTOCOL_REVISION : PVA_CLIENT_PROTOCOL_REVISION);
     _sendBuffer.putByte(
-        (_lastSegmentedMessageType | _byteOrderFlag | _clientServerFlag));	// data message
-    _sendBuffer.putByte(command);	// command
+        (_lastSegmentedMessageType | _byteOrderFlag | _clientServerFlag));  // data message
+    _sendBuffer.putByte(command);   // command
     _sendBuffer.putInt(payloadSize);
 
     // apply offset
@@ -619,13 +619,13 @@ void AbstractCodec::putControlMessage(
     epics::pvData::int32 data) {
 
     _lastMessageStartPosition =
-        std::numeric_limits<size_t>::max();		// TODO revise this
+        std::numeric_limits<size_t>::max();     // TODO revise this
     ensureBuffer(PVA_MESSAGE_HEADER_SIZE);
     _sendBuffer.putByte(PVA_MAGIC);
     _sendBuffer.putByte(_clientServerFlag ? PVA_SERVER_PROTOCOL_REVISION : PVA_CLIENT_PROTOCOL_REVISION);
-    _sendBuffer.putByte((0x01 | _byteOrderFlag | _clientServerFlag));	// control message
-    _sendBuffer.putByte(command);	// command
-    _sendBuffer.putInt(data);		// data
+    _sendBuffer.putByte((0x01 | _byteOrderFlag | _clientServerFlag));   // control message
+    _sendBuffer.putByte(command);   // command
+    _sendBuffer.putInt(data);       // data
 }
 
 
@@ -687,8 +687,8 @@ void AbstractCodec::endMessage(bool hasMoreSegments) {
         {
         sendBuffer.put(PVAConstants.PVA_MAGIC);
         sendBuffer.put(PVAConstants.PVA_VERSION);
-        sendBuffer.put((byte)(0x01 | byteOrderFlag));	// control data
-        sendBuffer.put((byte)0);	// marker
+        sendBuffer.put((byte)(0x01 | byteOrderFlag));   // control data
+        sendBuffer.put((byte)0);    // marker
         sendBuffer.putInt((int)(totalBytesSent + position +
         PVAConstants.PVA_MESSAGE_HEADER_SIZE));
         nextMarkerPosition = position + markerPeriodBytes;
@@ -845,9 +845,9 @@ void AbstractCodec::processSendQueue()
                 if (_sendBuffer.getPosition() > 0)
                     flush(true);
 
-                sendCompleted();	// do not schedule sending
+                sendCompleted();    // do not schedule sending
 
-                if (terminated())			// termination
+                if (terminated())   // termination
                     break;
                 // termination (we want to process even if shutdown)
                 _sendQueue.pop_front(sender);
@@ -1528,8 +1528,8 @@ void BlockingServerTCPTransportCodec::send(ByteBuffer* buffer,
         buffer->putByte(PVA_SERVER_PROTOCOL_REVISION);
         buffer->putByte(
             0x01 | 0x40 | ((EPICS_BYTE_ORDER == EPICS_ENDIAN_BIG)
-                           ? 0x80 : 0x00));		// control + server + endian
-        buffer->putByte(CMD_SET_ENDIANESS);		// set byte order
+                           ? 0x80 : 0x00));     // control + server + endian
+        buffer->putByte(CMD_SET_ENDIANESS);     // set byte order
         buffer->putInt(0);
 
 

--- a/src/remote/pv/beaconHandler.h
+++ b/src/remote/pv/beaconHandler.h
@@ -19,7 +19,7 @@
 
 #ifdef beaconHandlerEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef beaconHandlerEpicsExportSharedSymbols
+#       undef beaconHandlerEpicsExportSharedSymbols
 #endif
 
 #include <pv/pvaDefs.h>

--- a/src/remote/pv/blockingTCP.h
+++ b/src/remote/pv/blockingTCP.h
@@ -29,7 +29,7 @@
 
 #ifdef blockingTCPEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef blockingTCPEpicsExportSharedSymbols
+#       undef blockingTCPEpicsExportSharedSymbols
 #endif
 
 #include <pv/pvaConstants.h>

--- a/src/remote/pv/blockingUDP.h
+++ b/src/remote/pv/blockingUDP.h
@@ -24,7 +24,7 @@
 
 #ifdef blockingUDPEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef blockingUDPEpicsExportSharedSymbols
+#       undef blockingUDPEpicsExportSharedSymbols
 #endif
 
 #include <shareLib.h>

--- a/src/remote/pv/channelSearchManager.h
+++ b/src/remote/pv/channelSearchManager.h
@@ -16,7 +16,7 @@
 
 #ifdef channelSearchManagerEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef channelSearchManagerEpicsExportSharedSymbols
+#       undef channelSearchManagerEpicsExportSharedSymbols
 #endif
 
 #include <pv/pvaDefs.h>
@@ -43,8 +43,8 @@ public:
     /**
      * Search response from server (channel found).
      * @param guid server GUID.
-     * @param minorRevision	server minor PVA revision.
-     * @param serverAddress	server address.
+     * @param minorRevision     server minor PVA revision.
+     * @param serverAddress     server address.
      */
     // TODO make serverAddress an URI or similar
     virtual void searchResponse(const ServerGUID & guid, int8_t minorRevision, osiSockAddr* serverAddress) = 0;
@@ -81,10 +81,10 @@ public:
     /**
      * Search response from server (channel found).
      * @param guid  server GUID.
-     * @param cid	client channel ID.
-     * @param seqNo	search sequence number.
-     * @param minorRevision	server minor PVA revision.
-     * @param serverAddress	server address.
+     * @param cid       client channel ID.
+     * @param seqNo     search sequence number.
+     * @param minorRevision     server minor PVA revision.
+     * @param serverAddress     server address.
      */
     void searchResponse(const ServerGUID & guid, pvAccessID cid, int32_t seqNo, int8_t minorRevision, osiSockAddr* serverAddress);
     /**

--- a/src/remote/pv/remote.h
+++ b/src/remote/pv/remote.h
@@ -26,7 +26,7 @@
 
 #ifdef remoteEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef remoteEpicsExportSharedSymbols
+#       undef remoteEpicsExportSharedSymbols
 #endif
 
 #include <pv/pvaConstants.h>

--- a/src/remote/pv/security.h
+++ b/src/remote/pv/security.h
@@ -88,7 +88,7 @@
 
 #ifdef securityEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef securityEpicsExportSharedSymbols
+#       undef securityEpicsExportSharedSymbols
 #endif
 
 #include <pv/pvaDefs.h>

--- a/src/remote/pv/serializationHelper.h
+++ b/src/remote/pv/serializationHelper.h
@@ -38,7 +38,7 @@ public:
      * @param payloadBuffer data buffer.
      * @param control deserialization control.
      * @param existingStructure if deserialized Field matches <code>existingStrcuture</code> Field, then
-     * 			<code>existingStructure</code> instance is returned. <code>null</code> value is allowed.
+     *                  <code>existingStructure</code> instance is returned. <code>null</code> value is allowed.
      * @return PVStructure instance, can be <code>null</code>.
      */
     static epics::pvData::PVStructure::shared_pointer deserializeStructureAndCreatePVStructure(epics::pvData::ByteBuffer* payloadBuffer,

--- a/src/remote/pv/transportRegistry.h
+++ b/src/remote/pv/transportRegistry.h
@@ -26,7 +26,7 @@
 
 #ifdef transportRegistryEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef transportRegistryEpicsExportSharedSymbols
+#       undef transportRegistryEpicsExportSharedSymbols
 #endif
 
 #include <pv/remote.h>

--- a/src/remote/serializationHelper.cpp
+++ b/src/remote/serializationHelper.cpp
@@ -96,5 +96,3 @@ void SerializationHelper::serializeFull(ByteBuffer* buffer, SerializableControl*
 
 }
 }
-
-

--- a/src/remote/transportRegistry.cpp
+++ b/src/remote/transportRegistry.cpp
@@ -174,4 +174,3 @@ void TransportRegistry::toArray(transportVector_t & transportArray, const osiSoc
 
 }
 }
-

--- a/src/remoteClient/clientContextImpl.cpp
+++ b/src/remoteClient/clientContextImpl.cpp
@@ -4761,4 +4761,3 @@ ChannelProvider::shared_pointer createClientProvider(const Configuration::shared
 
 }
 };
-

--- a/src/remoteClient/pv/clientContextImpl.h
+++ b/src/remoteClient/pv/clientContextImpl.h
@@ -16,7 +16,7 @@
 
 #ifdef clientContextImplEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef clientContextImplEpicsExportSharedSymbols
+#       undef clientContextImplEpicsExportSharedSymbols
 #endif
 
 #include <pv/pvAccess.h>

--- a/src/rpcClient/pv/rpcClient.h
+++ b/src/rpcClient/pv/rpcClient.h
@@ -17,7 +17,7 @@
 #include <pv/valueBuilder.h>
 #ifdef rpcClientEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef rpcClientEpicsExportSharedSymbols
+#       undef rpcClientEpicsExportSharedSymbols
 #endif
 
 #include <pv/rpcService.h>

--- a/src/rpcService/pv/rpcServer.h
+++ b/src/rpcService/pv/rpcServer.h
@@ -16,7 +16,7 @@
 
 #ifdef rpcServerEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef rpcServerEpicsExportSharedSymbols
+#       undef rpcServerEpicsExportSharedSymbols
 #endif
 
 #include <pv/pvAccess.h>

--- a/src/rpcService/pv/rpcService.h
+++ b/src/rpcService/pv/rpcService.h
@@ -19,7 +19,7 @@
 
 #ifdef rpcServiceEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef rpcServiceEpicsExportSharedSymbols
+#       undef rpcServiceEpicsExportSharedSymbols
 #endif
 
 #include <pv/pvAccess.h>

--- a/src/server/beaconEmitter.cpp
+++ b/src/server/beaconEmitter.cpp
@@ -135,4 +135,3 @@ void BeaconEmitter::callback()
 
 }
 }
-

--- a/src/server/beaconServerStatusProvider.cpp
+++ b/src/server/beaconServerStatusProvider.cpp
@@ -35,4 +35,3 @@ PVField::shared_pointer DefaultBeaconServerStatusProvider::getServerStatusData()
 
 }
 }
-

--- a/src/server/pv/beaconEmitter.h
+++ b/src/server/pv/beaconEmitter.h
@@ -20,7 +20,7 @@
 
 #ifdef beaconEmitterEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef beaconEmitterEpicsExportSharedSymbols
+#       undef beaconEmitterEpicsExportSharedSymbols
 #endif
 
 #include <pv/remote.h>
@@ -49,10 +49,10 @@ public:
     /**
      * Constructor.
      * @param protocol a protocol (transport) name to report.
-     * @param transport	transport to be used to send beacons.
+     * @param transport transport to be used to send beacons.
      * @param context PVA context.
      */
-//		BeaconEmitter(std::sting const & protocol,
+//              BeaconEmitter(std::sting const & protocol,
 //          Transport::shared_pointer const & transport, ServerContextImpl::shared_pointer const & context);
     BeaconEmitter(std::string const & protocol,
                   Transport::shared_pointer const & transport, std::tr1::shared_ptr<ServerContextImpl>& context);

--- a/src/server/pv/beaconServerStatusProvider.h
+++ b/src/server/pv/beaconServerStatusProvider.h
@@ -54,7 +54,7 @@ public:
      * Constructor.
      * @param context PVA context.
      */
-//		DefaultBeaconServerStatusProvider(ServerContext::shared_pointer const & context);
+//              DefaultBeaconServerStatusProvider(ServerContext::shared_pointer const & context);
     DefaultBeaconServerStatusProvider(std::tr1::shared_ptr<ServerContext> const & context);
     /**
      * Destructor.

--- a/src/server/pv/serverContext.h
+++ b/src/server/pv/serverContext.h
@@ -48,8 +48,8 @@ public:
 
     /**
      * Run server (process events).
-     * @param	seconds	time in seconds the server will process events (method will block), if <code>0</code>
-     * 				the method would block until <code>destroy()</code> is called.
+     * @param   seconds time in seconds the server will process events (method will block), if <code>0</code>
+     *                          the method would block until <code>destroy()</code> is called.
      * @throws BaseException if server is already destroyed.
      */
     virtual void run(epics::pvData::uint32 seconds) = 0;

--- a/src/server/pv/serverContextImpl.h
+++ b/src/server/pv/serverContextImpl.h
@@ -10,7 +10,7 @@
 
 #ifdef serverContextImplEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef serverContextImplEpicsExportSharedSymbols
+#       undef serverContextImplEpicsExportSharedSymbols
 #endif
 
 #include <pv/blockingUDP.h>

--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -1072,28 +1072,28 @@ void ServerGetHandler::handleResponse(osiSockAddr* responseFrom,
     } \
     catch (std::exception &e) { \
         Status status(Status::STATUSTYPE_FATAL, e.what()); \
-	    BaseChannelRequester::sendFailureMessage((int8)cmd, _transport, _ioid, (int8)QOS_INIT, status); \
-	    destroy(); \
+        BaseChannelRequester::sendFailureMessage((int8)cmd, _transport, _ioid, (int8)QOS_INIT, status); \
+        destroy(); \
     } \
     catch (...) { \
         Status status(Status::STATUSTYPE_FATAL, "unknown exception caught"); \
-	    BaseChannelRequester::sendFailureMessage((int8)cmd, _transport, _ioid, (int8)QOS_INIT, status); \
-	    destroy(); \
+        BaseChannelRequester::sendFailureMessage((int8)cmd, _transport, _ioid, (int8)QOS_INIT, status); \
+        destroy(); \
     }
 
 #define DESERIALIZE_EXCEPTION_GUARD(code) \
     try { \
- 	    code; \
+        code; \
     } \
     catch (std::exception &e) { \
         Status status(Status::STATUSTYPE_ERROR, e.what()); \
-	    BaseChannelRequester::sendFailureMessage((int8)command, transport, ioid, qosCode, status); \
-	    throw; \
+        BaseChannelRequester::sendFailureMessage((int8)command, transport, ioid, qosCode, status); \
+        throw; \
     } \
     catch (...) { \
         Status status(Status::STATUSTYPE_ERROR, "unknown exception caught"); \
-	    BaseChannelRequester::sendFailureMessage((int8)command, transport, ioid, qosCode, status); \
-	    throw; \
+        BaseChannelRequester::sendFailureMessage((int8)command, transport, ioid, qosCode, status); \
+        throw; \
     }
 
 ServerChannelGetRequesterImpl::ServerChannelGetRequesterImpl(ServerContextImpl::shared_pointer const & context, ServerChannel::shared_pointer const & channel, const pvAccessID ioid, Transport::shared_pointer const & transport) :
@@ -1835,8 +1835,8 @@ void ServerMonitorHandler::handleResponse(osiSockAddr* responseFrom,
         /*
         if (!request->startRequest(qosCode))
         {
-        	BaseChannelRequester::sendFailureMessage((int8)CMD_MONITOR, transport, ioid, qosCode, BaseChannelRequester::otherRequestPendingStatus);
-        	return;
+            BaseChannelRequester::sendFailureMessage((int8)CMD_MONITOR, transport, ioid, qosCode, BaseChannelRequester::otherRequestPendingStatus);
+            return;
         }
         */
 

--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -453,7 +453,7 @@ void ServerChannelFindRequesterImpl::channelFindResult(const Status& /*status*/,
             _context->s_channelNameToProvider[_name] = channelFind->getChannelProvider();
         }
         _wasFound = wasFound;
-        
+
         BlockingUDPTransport::shared_pointer bt = _context->getBroadcastTransport();
         if (bt)
         {

--- a/src/utils/configuration.cpp
+++ b/src/utils/configuration.cpp
@@ -257,4 +257,3 @@ ConfigurationProvider::shared_pointer ConfigurationFactory::getProvider()
 
 }
 }
-

--- a/src/utils/inetAddressUtil.cpp
+++ b/src/utils/inetAddressUtil.cpp
@@ -361,13 +361,13 @@ int discoverInterfaces(IfaceNodeVector &list, SOCKET socket, const osiSockAddr *
 
 int discoverInterfaces(IfaceNodeVector &list, SOCKET socket, const osiSockAddr *pMatchAddr)
 {
-    int             	status;
+    int                 status;
     INTERFACE_INFO      *pIfinfo;
     INTERFACE_INFO      *pIfinfoList;
-    unsigned			nelem;
-    int					numifs;
-    DWORD				cbBytesReturned;
-    int					match;
+    unsigned            nelem;
+    int                 numifs;
+    DWORD               cbBytesReturned;
+    int                 match;
 
     /* only valid for winsock 2 and above
     TODO resolve dllimport compilation problem and uncomment this check

--- a/src/utils/introspectionRegistry.cpp
+++ b/src/utils/introspectionRegistry.cpp
@@ -141,4 +141,3 @@ FieldConstPtr IntrospectionRegistry::deserialize(ByteBuffer* buffer, Deserializa
 
 }
 }
-

--- a/src/utils/introspectionRegistry.cpp
+++ b/src/utils/introspectionRegistry.cpp
@@ -91,7 +91,7 @@ void IntrospectionRegistry::serialize(FieldConstPtr const & field, ByteBuffer* b
             }
             else {
                 control->ensureBuffer(3);
-                buffer->putByte(FULL_WITH_ID_TYPE_CODE);	// could also be a mask
+                buffer->putByte(FULL_WITH_ID_TYPE_CODE);    // could also be a mask
                 buffer->putShort(key);
             }
         }

--- a/src/utils/pv/hexDump.h
+++ b/src/utils/pv/hexDump.h
@@ -16,7 +16,7 @@
 
 #include <pv/pvType.h>
 
-#ifdef	hexDumpEpicsExportSharedSymbols
+#ifdef  hexDumpEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
 #   undef hexDumpEpicsExportSharedSymbols
 #endif

--- a/src/utils/pv/introspectionRegistry.h
+++ b/src/utils/pv/introspectionRegistry.h
@@ -26,7 +26,7 @@
 
 #ifdef introspectionRegistryEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef introspectionRegistryEpicsExportSharedSymbols
+#       undef introspectionRegistryEpicsExportSharedSymbols
 #endif
 
 // TODO check for memory leaks

--- a/src/utils/pv/referenceCountingLock.h
+++ b/src/utils/pv/referenceCountingLock.h
@@ -18,7 +18,7 @@
 
 #ifdef referenceCountingLockEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef referenceCountingLockEpicsExportSharedSymbols
+#       undef referenceCountingLockEpicsExportSharedSymbols
 #endif
 
 namespace epics {
@@ -52,11 +52,11 @@ public:
      * NOTE: Argument msecs is currently not supported due to
      * Darwin OS not supporting pthread_mutex_timedlock. May be changed in the future.
      *
-     * @param	msecs	the number of milleseconds to wait.
-     * 					An argument less than or equal to zero means not to wait at all.
+     * @param   msecs   the number of milleseconds to wait.
+     *                                  An argument less than or equal to zero means not to wait at all.
      *
-     * @return	<code>true</code> if acquired, <code>false</code> otherwise.
-     * 			NOTE: currently this routine always returns true. Look above for explanation.
+     * @return  <code>true</code> if acquired, <code>false</code> otherwise.
+     *                  NOTE: currently this routine always returns true. Look above for explanation.
      *
      */
     bool acquire(epics::pvData::int64 msecs);

--- a/src/utils/pv/requester.h
+++ b/src/utils/pv/requester.h
@@ -20,7 +20,7 @@
 
 #ifdef requesterEpicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#	undef requesterEpicsExportSharedSymbols
+#       undef requesterEpicsExportSharedSymbols
 #endif
 
 

--- a/src/utils/referenceCountingLock.cpp
+++ b/src/utils/referenceCountingLock.cpp
@@ -98,4 +98,3 @@ int ReferenceCountingLock::decrement()
 
 }
 }
-

--- a/src/utils/referenceCountingLock.cpp
+++ b/src/utils/referenceCountingLock.cpp
@@ -14,71 +14,71 @@ using namespace epics::pvData;
 
 ReferenceCountingLock::ReferenceCountingLock(): _references(1)
 {
-    /*	pthread_mutexattr_t mutexAttribute;
-    	int32 retval = pthread_mutexattr_init(&mutexAttribute);
-    	if(retval != 0)
-    	{
-    		//string errMsg = "Error: pthread_mutexattr_init failed: " + string(strerror(retval));
-    		assert(false);
-    	}
-    	retval = pthread_mutexattr_settype(&mutexAttribute, PTHREAD_MUTEX_RECURSIVE);
-    	if(retval == 0)
-    	{
-    		retval = pthread_mutex_init(_mutex, &mutexAttribute);
-    		if(retval != 0)
-    		{
-    			//string errMsg = "Error: pthread_mutex_init failed: " + string(strerror(retval));
-    			assert(false);
-    		}
-    	}
-    	else
-    	{
-    		//string errMsg = "Error: pthread_mutexattr_settype failed: " + string(strerror(retval));
-    		assert(false);
-    	}
+    /*  pthread_mutexattr_t mutexAttribute;
+        int32 retval = pthread_mutexattr_init(&mutexAttribute);
+        if(retval != 0)
+        {
+            //string errMsg = "Error: pthread_mutexattr_init failed: " + string(strerror(retval));
+            assert(false);
+        }
+        retval = pthread_mutexattr_settype(&mutexAttribute, PTHREAD_MUTEX_RECURSIVE);
+        if(retval == 0)
+        {
+            retval = pthread_mutex_init(_mutex, &mutexAttribute);
+            if(retval != 0)
+            {
+                //string errMsg = "Error: pthread_mutex_init failed: " + string(strerror(retval));
+                assert(false);
+            }
+        }
+        else
+        {
+            //string errMsg = "Error: pthread_mutexattr_settype failed: " + string(strerror(retval));
+            assert(false);
+        }
 
-    	pthread_mutexattr_destroy(&mutexAttribute);*/
+        pthread_mutexattr_destroy(&mutexAttribute);*/
 }
 
 ReferenceCountingLock::~ReferenceCountingLock()
 {
-//	pthread_mutex_destroy(_mutex);
+//  pthread_mutex_destroy(_mutex);
 }
 
 bool ReferenceCountingLock::acquire(int64 /*msecs*/)
 {
     _mutex.lock();
     return true;
-    /*	struct timespec deltatime;
-    	if(msecs > 0)
-    	{
-    		deltatime.tv_sec = msecs / 1000;
-    		deltatime.tv_nsec = (msecs % 1000) * 1000;
-    	}
-    	else
-    	{
-    		deltatime.tv_sec = 0;
-    		deltatime.tv_nsec = 0;
-    	}
+    /*  struct timespec deltatime;
+        if(msecs > 0)
+        {
+            deltatime.tv_sec = msecs / 1000;
+            deltatime.tv_nsec = (msecs % 1000) * 1000;
+        }
+        else
+        {
+            deltatime.tv_sec = 0;
+            deltatime.tv_nsec = 0;
+        }
 
-    	int32 retval = pthread_mutex_timedlock(_mutex, &deltatime);
-    	if(retval == 0)
-    	{
-    		return true;
-    	}
-    	return false;
+        int32 retval = pthread_mutex_timedlock(_mutex, &deltatime);
+        if(retval == 0)
+        {
+            return true;
+        }
+        return false;
     */
 }
 
 void ReferenceCountingLock::release()
 {
     _mutex.unlock();
-    /*	int retval = pthread_mutex_unlock(_mutex);
-    	if(retval != 0)
-    	{
-    		//string errMsg = "Error: pthread_mutex_unlock failed: "  + string(strerror(retval));
-    		//TODO do something?
-    	}*/
+    /*  int retval = pthread_mutex_unlock(_mutex);
+        if(retval != 0)
+        {
+            //string errMsg = "Error: pthread_mutex_unlock failed: "  + string(strerror(retval));
+            //TODO do something?
+        }*/
 }
 
 // TODO use atomic primitive impl.

--- a/testApp/remote/channelAccessIFTest.cpp
+++ b/testApp/remote/channelAccessIFTest.cpp
@@ -54,7 +54,7 @@ const std::string ChannelAccessIFTest::TEST_ARRAY_CHANNEL_NAME = "testArray1";
 template <typename T>
 inline bool compareWithTol(const T v1, const T v2, const T tol)
 {
-	return (std::fabs(v1 - v2) <= tol);
+    return (std::fabs(v1 - v2) <= tol);
 }
 
 int ChannelAccessIFTest::runAllTest() {

--- a/testApp/remote/testADCSim.cpp
+++ b/testApp/remote/testADCSim.cpp
@@ -366,4 +366,3 @@ SimADC::smart_pointer_type getSimADC(const std::string& name)
 
     return it->second;
 }
-

--- a/testApp/remote/testCodec.cpp
+++ b/testApp/remote/testCodec.cpp
@@ -138,7 +138,7 @@ public:
         std::size_t startPos = _readBuffer->getPosition();
         //buffer.put(readBuffer);
         //while (buffer.hasRemaining() && readBuffer.hasRemaining())
-        //	buffer.put(readBuffer.get());
+        //  buffer.put(readBuffer.get());
 
         std::size_t bufferRemaining = buffer->getRemaining();
         std::size_t readBufferRemaining =
@@ -164,7 +164,7 @@ public:
 
     int write(ByteBuffer *buffer) {
         if (_disconnected)
-            return -1;	// TODO: not by the JavaDoc API spec
+            return -1;  // TODO: not by the JavaDoc API spec
 
         if (_throwExceptionOnSend)
             throw io_exception("text IO exception");
@@ -1312,7 +1312,7 @@ private:
     {
         testDiag("BEGIN TEST %s:", CURRENT_FUNCTION);
 
-        for (int32_t firstMessagePayloadSize = 1;	// cannot be zero
+        for (int32_t firstMessagePayloadSize = 1;   // cannot be zero
                 firstMessagePayloadSize <= 3;
                 firstMessagePayloadSize++)
         {
@@ -1763,7 +1763,7 @@ private:
     {
         testDiag("BEGIN TEST %s:", CURRENT_FUNCTION);
 
-        for (int32_t firstMessagePayloadSize = 1;	// cannot be zero
+        for (int32_t firstMessagePayloadSize = 1;   // cannot be zero
                 firstMessagePayloadSize <= 3;
                 firstMessagePayloadSize++)
         {
@@ -1925,7 +1925,7 @@ private:
         testDiag("BEGIN TEST %s:", CURRENT_FUNCTION);
 
 
-        for (int32_t firstMessagePayloadSize = 1;	// cannot be zero
+        for (int32_t firstMessagePayloadSize = 1;   // cannot be zero
                 firstMessagePayloadSize <= 3;
                 firstMessagePayloadSize++)
         {
@@ -2566,7 +2566,7 @@ private:
 
         void writePollOne() {
             testDiag("In %s", CURRENT_FUNCTION);
-            _codec.processWrite();	// this should return immediately
+            _codec.processWrite();  // this should return immediately
 
             // now we fake reading
             _codec._writeBuffer.flip();

--- a/testApp/remote/testGetPerformance.cpp
+++ b/testApp/remote/testGetPerformance.cpp
@@ -204,7 +204,7 @@ public:
                     printf("%d %d %d %d %.3f\n", channels, arraySize, iterations, runs, sum/runs);
 
                     Lock guard(waitLoopPtrMutex);
-                    waitLoopEvent->signal();	// all done
+                    waitLoopEvent->signal();    // all done
                 }
             }
             else if (channelCount == 0)

--- a/testApp/remote/testMonitorPerformance.cpp
+++ b/testApp/remote/testMonitorPerformance.cpp
@@ -196,7 +196,7 @@ public:
                     printf("%d %d %d %d %.3f\n", channels, arraySize, iterations, runs, sum/runs);
 
                     Lock guard(waitLoopPtrMutex);
-                    waitLoopEvent->signal();	// all done
+                    waitLoopEvent->signal();    // all done
                 }
             }
             else if (channelCount == 0)

--- a/testApp/remote/testServer.cpp
+++ b/testApp/remote/testServer.cpp
@@ -2503,7 +2503,7 @@ private:
 };
 
 
-class MockServerChannelProvider : 	public ChannelProvider,
+class MockServerChannelProvider :   public ChannelProvider,
     public std::tr1::enable_shared_from_this<MockServerChannelProvider>
 {
 public:

--- a/testApp/utils/configurationTest.cpp
+++ b/testApp/utils/configurationTest.cpp
@@ -145,6 +145,3 @@ MAIN(configurationTest)
     testConfig();
     return testDone();
 }
-
-
-

--- a/testApp/utils/testInetAddressUtils.cpp
+++ b/testApp/utils/testInetAddressUtils.cpp
@@ -314,4 +314,3 @@ MAIN(testInetAddressUtils)
 
     return testDone();
 }
-

--- a/testCa/testCaProvider.cpp
+++ b/testCa/testCaProvider.cpp
@@ -173,7 +173,7 @@ private:
         TestChannelGetRequesterPtr const &getRequester,
         TestChannelPtr const &testChannel,
         PVStructurePtr const &  pvRequest);
-    
+
     TestChannelGetRequesterWPtr getRequester;
     TestChannelPtr testChannel;
     PVStructurePtr pvRequest;
@@ -293,7 +293,7 @@ private:
     TestChannelPut(
         TestChannelPutRequesterPtr const &putRequester,
         TestChannelPtr const &testChannel);
-    
+
     TestChannelPutRequesterWPtr putRequester;
     TestChannelPtr testChannel;
     PVStructurePtr pvStructure;
@@ -362,7 +362,7 @@ void TestChannelPut::connect()
 {
     string request("value");
     PVStructurePtr pvRequest(createRequest(request));
-    
+
     channelPut = testChannel->getChannel()->createChannelPut(shared_from_this(),pvRequest);
     if(!channelPut) throw std::runtime_error(testChannel->getChannelName() + " channelCreate failed ");
 }
@@ -370,7 +370,7 @@ void TestChannelPut::connect()
 void TestChannelPut::waitConnect(double timeout)
 {
     if(waitForConnect.wait(timeout)) return;
-    throw std::runtime_error(testChannel->getChannelName() 
+    throw std::runtime_error(testChannel->getChannelName()
         + " TestChannelPut::waitConnect failed ");
 }
 
@@ -378,7 +378,7 @@ void TestChannelPut::waitConnect(double timeout)
 void TestChannelPut::put(string const & value)
 {
     PVFieldPtr pvField(pvStructure->getSubField("value"));
-    if(!pvField) throw std::runtime_error(testChannel->getChannelName() 
+    if(!pvField) throw std::runtime_error(testChannel->getChannelName()
          + " TestChannelPut::put no value ");
     FieldConstPtr field(pvField->getField());
     Type type(field->getType());
@@ -403,10 +403,10 @@ void TestChannelPut::put(string const & value)
             }
             values.push_back(value.substr(pos,offset-pos));
             pos = offset+1;
-            n++;    
+            n++;
         }
         pvScalarArray->setLength(n);
-        getConvert()->fromStringArray(pvScalarArray,0,n,values,0);       
+        getConvert()->fromStringArray(pvScalarArray,0,n,values,0);
         bitSet->set(pvField->getFieldOffset());
         channelPut->put(pvStructure,bitSet);
         return;
@@ -420,7 +420,7 @@ void TestChannelPut::put(string const & value)
           return;
        }
     }
-    throw std::runtime_error(testChannel->getChannelName() 
+    throw std::runtime_error(testChannel->getChannelName()
         + " TestChannelPut::put not supported  type");
 }
 
@@ -465,7 +465,7 @@ private:
         TestChannelMonitorRequesterPtr const &putRequester,
         TestChannelPtr const &testChannel,
         PVStructurePtr const &  pvRequest);
-    
+
     TestChannelMonitorRequesterWPtr monitorRequester;
     TestChannelPtr testChannel;
     PVStructurePtr pvRequest;
@@ -503,7 +503,7 @@ void TestChannelMonitor::monitorConnect(
 {
     waitForConnect.signal();
 }
-    
+
 
 void TestChannelMonitor::monitorEvent(MonitorPtr const & monitor)
 {
@@ -722,7 +722,7 @@ void TestIoc::start()
         "testIoc",
         epicsThreadGetStackSize(epicsThreadStackBig),
         epicsThreadPriorityLow));
-    thread->start();  
+    thread->start();
 #endif
 }
 
@@ -768,7 +768,7 @@ MAIN(testCaProvider)
     testPlan(143 + EXIT_TESTS);
 
     TestIocPtr testIoc(new TestIoc());
-    testIoc->start();  
+    testIoc->start();
 
     testDiag("===Test caProvider===");
     CAClientFactory::start();
@@ -819,4 +819,3 @@ MAIN(testCaProvider)
 
     return testDone();;
 }
-


### PR DESCRIPTION
This is purely cosmetic:
1. There was a mess with tab character usage. Indention with spaces and tabs was mixed inconsistently sometimes with obviously different assumptions on tab width, even in the same file. This results in irregular, hard to read indents. Please stop using tabs in source code.
2. Clean up of space at end of line.
3. Clean up of empty lines at end of file.