### PR TITLE
testCaProvider on Windows with Base-3.15

### DIFF
--- a/testCa/testCaProvider.cpp
+++ b/testCa/testCaProvider.cpp
@@ -771,6 +771,12 @@ MAIN(testCaProvider)
 {
     testPlan(143 + EXIT_TESTS);
 
+#ifdef USE_DBUNITTEST
+    testDiag("Running IOC using dbUnitTest");
+#else
+    testDiag("Running IOC using system()");
+#endif
+
     TestIocPtr testIoc(new TestIoc());
     testIoc->start();
 

--- a/testCa/testCaProvider.cpp
+++ b/testCa/testCaProvider.cpp
@@ -27,6 +27,8 @@
     #include <dbUnitTest.h>
 
     extern "C" int testIoc_registerRecordDeviceDriver(struct dbBase *pbase);
+  #else
+    #include <osiFileName.h>
   #endif
 #endif
 
@@ -733,12 +735,14 @@ void TestIoc::run()
     // tests with an embedded IOC fail with a Base before 3.16.2.
     // This version only works on workstation targets, it runs the
     // softIoc from Base as a separate process, using system().
-    if(system("$EPICS_BASE/bin/$EPICS_HOST_ARCH/softIoc -x test -d ../testCaProvider.db")!=0) {
-        string message(base);
-        message += "/bin/";
-        message += arch;
-        message += "/softIoc -d ../testCaProvider.db not started";
-        throw std::runtime_error(message);
+    string cmd(base);
+    cmd += OSI_PATH_SEPARATOR "bin" OSI_PATH_SEPARATOR;
+    cmd += arch;
+    cmd += OSI_PATH_SEPARATOR "softIoc -x test -d ../testCaProvider.db";
+    if (system(cmd.c_str()) != 0) {
+        string message(cmd);
+        cmd += " not started";
+        throw std::runtime_error(cmd);
     }
 #endif
 }

--- a/testCa/testCaProvider.cpp
+++ b/testCa/testCaProvider.cpp
@@ -17,7 +17,7 @@
 #include <envDefs.h>
 
 #ifdef EPICS_VERSION_INT
-  #if EPICS_VERSION_INT >= VERSION_INT(3,16,2,0)
+  #if !defined(USE_SOFTIOC) && EPICS_VERSION_INT >= VERSION_INT(3,16,2,0)
     #define USE_DBUNITTEST
     // USE_TYPED_RSET prevents deprecation warnings
     #define USE_TYPED_RSET


### PR DESCRIPTION
This should let testCaProvider start its external softIoc properly on Windows when built with a Base version too old to provide dbUnitTest.

I haven't actually tested this on Windows myself, but it does work on Darwin and I'm using OS-Independent APIs so I'm reasonably confident that it should work.