### PR TITLE
RTEMS socket close() hack

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -75,14 +75,12 @@ jobs:
             configuration: default
             base: "7.0"
             rtems: "4.10"
-            test: NO
 
           - os: ubuntu-20.04
             cmp: gcc
             configuration: default
             base: "7.0"
             rtems: "4.9"
-            test: NO
 
           - os: ubuntu-16.04
             cmp: gcc-4.8

--- a/src/remote/blockingTCPAcceptor.cpp
+++ b/src/remote/blockingTCPAcceptor.cpp
@@ -248,6 +248,7 @@ void BlockingTCPAcceptor::destroy() {
         {
         case esscimqi_socketBothShutdownRequired:
             shutdown(sock, SHUT_RDWR);
+            hackAroundRTEMSSocketInterrupt();
             epicsSocketDestroy(sock);
             _thread.exitWait();
             break;

--- a/src/remote/blockingUDPTransport.cpp
+++ b/src/remote/blockingUDPTransport.cpp
@@ -151,6 +151,7 @@ void BlockingUDPTransport::close(bool waitForThreadToComplete) {
     case esscimqi_socketBothShutdownRequired:
     {
         /*int status =*/ ::shutdown ( _channel, SHUT_RDWR );
+        hackAroundRTEMSSocketInterrupt();
         /*
         if ( status ) {
             char sockErrBuf[64];

--- a/src/remote/pv/remote.h
+++ b/src/remote/pv/remote.h
@@ -114,6 +114,8 @@ enum ControlCommands {
     CMD_SET_ENDIANESS = 2
 };
 
+void hackAroundRTEMSSocketInterrupt();
+
 /**
  * Interface defining transport send control.
  */

--- a/testApp/remote/Makefile
+++ b/testApp/remote/Makefile
@@ -5,7 +5,9 @@ SRC_DIRS += $(PVACCESS_TEST)/remote
 TESTPROD_HOST += testChannelAccess
 testChannelAccess_SRCS = channelAccessIFTest.cpp
 testHarness_SRCS += channelAccessIFTest.cpp
+ifneq (RTEMS,$(OS_CLASS))
 TESTS += testChannelAccess
+endif
 
 TESTPROD_HOST += testCodec
 testCodec_SRCS = testCodec


### PR DESCRIPTION
RTEMS allows blocking sockets to be interrupted by `shutdown()` (aka. `esscimqi_socketBothShutdownRequired`).  However, a concurrent `close()` is a race which can leave a `send()`/`recv()` call permanently stuck!  The _right_ way to handle this (aside from fixing the stack) would be to sequence `shutdown()` -> `exitWait()` -> `epicsSocketDestroy()`.  This is hard to handle since this must be done for _both_ sender and receiver thread, which presents difficulties owing to how the `Transport` hierarchy is structured since `Transport::close()` can happen on either worker, or a user thread.

Rather than try to straighten this mess out properly, we add this "wait" in-between `shutdown()` and `epicsSocketDestroy()` to hopefully wait for the workers (or other worker) to return from `send()`/`recv()`.


cf. #150
