### PR TITLE
Enable building of pvtools to all except vxWorks, RTEMS and iOS.

### DIFF
--- a/pvtoolsSrc/Makefile
+++ b/pvtoolsSrc/Makefile
@@ -5,32 +5,36 @@ include $(TOP)/configure/CONFIG
 USR_CPPFLAGS += -I$(TOP)/src/utils
 USR_CPPFLAGS += -I$(TOP)/src/remote
 
-PROD_HOST += pvget
+PROD_DEFAULT += pvget
 pvget_SRCS += pvget.cpp
 pvget_SRCS += pvutils.cpp
 
-PROD_HOST += pvmonitor
+PROD_DEFAULT += pvmonitor
 pvmonitor_SRCS += pvmonitor.cpp
 pvmonitor_SRCS += pvutils.cpp
 
-PROD_HOST += pvput
+PROD_DEFAULT += pvput
 pvput_SRCS += pvput.cpp
 pvput_SRCS += pvutils.cpp
 
-PROD_HOST += pvcall
+PROD_DEFAULT += pvcall
 pvcall_SRCS += pvcall.cpp
 pvcall_SRCS += pvutils.cpp
 
-PROD_HOST += pvinfo
+PROD_DEFAULT += pvinfo
 pvinfo_SRCS += pvinfo.cpp
 pvinfo_SRCS += pvutils.cpp
 
-PROD_HOST += pvlist
+PROD_DEFAULT += pvlist
 pvlist_SRCS += pvlist.cpp
 
 PROD_LIBS += pvAccessCA pvAccess pvData ca Com
 
 PROD_SYS_LIBS_WIN32 += netapi32 ws2_32
+
+PROD_vxWorks = -nil-
+PROD_RTEMS = -nil-
+PROD_iOS = -nil-
 
 include $(TOP)/configure/RULES
 #----------------------------------------


### PR DESCRIPTION
EPICS Base tools build for host and also cross targets that are not vxWorks, RTEMS and iOS (https://github.com/epics-base/epics-base/blob/7.0/modules/ca/src/tools/Makefile#L16-L19). pvAccessCPP pvtools build only for host.

This PR makes so the pvAccessCPP pvtools follow the same standard.

This was tested at SLAC using a couple of cross targets that included RTEMS and linuxRT.
The tools were available for linuxRT and not RTEMS as expected.