### PR TITLE
Handle inputs with "=" to pvput

### DIFF
--- a/pvtoolsSrc/pvput.cpp
+++ b/pvtoolsSrc/pvput.cpp
@@ -112,8 +112,16 @@ struct Putter : public pvac::ClientChannel::PutCallback
             if(sep==std::string::npos) {
                 bare.push_back(values[i]);
             } else {
-                pairs.push_back(std::make_pair(values[i].substr(0, sep),
-                                               values[i].substr(sep+1)));
+                pvd::PVFieldPtr fld(root->getSubField(values[i].substr(0, sep)));
+                if(fld)
+                    // If the first substring is a valid "field", tread this value
+                    // as a field=value pair
+                    pairs.push_back(std::make_pair(values[i].substr(0, sep),
+                                                   values[i].substr(sep+1)));
+                else
+                    // If the first substring is not a valid "field", then tread this
+                    // value as a bare value instead
+                    bare.push_back(values[i]);
             }
         }
 

--- a/pvtoolsSrc/pvput.cpp
+++ b/pvtoolsSrc/pvput.cpp
@@ -138,6 +138,9 @@ struct Putter : public pvac::ClientChannel::PutCallback
 
         if(!bare.empty() && !pairs.empty()) {
             throw std::runtime_error("Can't mix bare values and field=value pairs");
+        } else if(bare.empty() && pairs.empty()) {
+            // We could have ignored all the value at this point
+            throw std::runtime_error("No valid value(s) specified");
         } else if(bare.size()==1 && bare[0][0]=='[') {
             // treat plain "[...]" as "value=[...]"
             pairs.push_back(std::make_pair("value", bare[0]));


### PR DESCRIPTION
This PR resolves #168 

The argument handling code of the `pvput` tool was reworked in order to handle bare value with `=` characters, which could be used for example to write to `DESC` or `CALC` fields. 

When trying to tread an input argument as a `field=value` pair, the code verifies if the `field` exists in the remote PV structure. If it doesn't exist, then it checks if the `.value` field is of type `string` and if it is, then the whole input value is treated as a bare value; otherwise the input is ignored (due to the `filed` being invalid).