### PR TITLE
Fix for CA put using PV structures that do not have subfield "value"

### DIFF
--- a/src/ca/dbdToPv.cpp
+++ b/src/ca/dbdToPv.cpp
@@ -830,6 +830,9 @@ Status DbdToPv::putToDBD(
     dbr_double_t dvalue(0);
     if(isArray) {
        PVScalarArrayPtr pvValue = pvStructure->getSubField<PVScalarArray>("value");
+       if(!pvValue) {
+           return Status(Status::STATUSTYPE_ERROR, string("DbdToPv::putToDBD logic error"));
+       }
        switch(caValueType) {
            case DBR_STRING:
            {
@@ -919,6 +922,9 @@ Status DbdToPv::putToDBD(
            }
     } else {
         PVScalarPtr pvValue = pvStructure->getSubField<PVScalar>("value");
+        if(!pvValue) {
+            return Status(Status::STATUSTYPE_ERROR, string("DbdToPv::putToDBD logic error"));
+        }
         switch(caValueType) {
            case DBR_ENUM:
            {

--- a/src/ca/dbdToPv.cpp
+++ b/src/ca/dbdToPv.cpp
@@ -922,7 +922,7 @@ Status DbdToPv::putToDBD(
            }
     } else {
         PVScalarPtr pvValue = pvStructure->getSubField<PVScalar>("value");
-        if(!pvValue) {
+        if(!pvValue && caValueType != DBR_ENUM) {
             return Status(Status::STATUSTYPE_ERROR, string("DbdToPv::putToDBD logic error"));
         }
         switch(caValueType) {


### PR DESCRIPTION
The problem was described here: https://github.com/epics-base/pvaPy/issues/61