### PR TITLE
CA Provider speed-up when connecting tens of thousands of CA channels

### DIFF
--- a/documentation/release_notes.dox
+++ b/documentation/release_notes.dox
@@ -1,5 +1,13 @@
 /** @page pvarelease_notes Release Notes
 
+Release 7.1.6 (UNRELEASED)
+=========================
+
+- Changes to caProvider
+  - More internal changes to improve performance when connecting tens of
+    thousands of CA channels.
+
+
 Release 7.1.5 (October 2021)
 ==========================
 

--- a/src/ca/caChannel.cpp
+++ b/src/ca/caChannel.cpp
@@ -116,6 +116,8 @@ CAChannel::CAChannel(std::string const & channelName,
     connectNotification(new Notification()),
     ca_context(channelProvider->caContext())
 {
+    if (channelName.empty())
+        throw std::invalid_argument("Channel name cannot be empty");
 }
 
 void CAChannel::activate(short priority)

--- a/src/ca/caChannel.cpp
+++ b/src/ca/caChannel.cpp
@@ -145,10 +145,6 @@ void CAChannel::activate(short priority)
 
 CAChannel::~CAChannel()
 {
-    {
-        epicsGuard<epicsMutex> G(requestsMutex);
-        if (!channelCreated) return;
-    }
     disconnectChannel();
 }
 

--- a/src/ca/caChannel.cpp
+++ b/src/ca/caChannel.cpp
@@ -132,7 +132,7 @@ void CAChannel::activate(short priority)
         channelCreated = true;
         CAChannelProviderPtr provider(channelProvider.lock());
         if (provider)
-            provider->addChannel(shared_from_this());
+            provider->addChannel(*this);
         EXCEPTION_GUARD(req->channelCreated(Status::Ok, shared_from_this()));
     }
     else {
@@ -167,10 +167,14 @@ void CAChannel::disconnectChannel()
     /* Clear CA Channel */
     Attach to(ca_context);
     int result = ca_clear_channel(channelID);
-    if (result == ECA_NORMAL) return;
-    string mess("CAChannel::disconnectChannel() ");
-    mess += ca_message(result);
-    cerr << mess << endl;
+    if (result != ECA_NORMAL) {
+        string mess("CAChannel::disconnectChannel() ");
+        mess += ca_message(result);
+        cerr << mess << endl;
+    }
+    CAChannelProviderPtr provider(channelProvider.lock());
+    if (provider)
+        provider->delChannel(*this);
 }
 
 chid CAChannel::getChannelID()

--- a/src/ca/caChannel.h
+++ b/src/ca/caChannel.h
@@ -18,6 +18,7 @@
 #include <epicsMutex.h>
 #include <epicsEvent.h>
 #include <cadef.h>
+#include <tsDLList.h>
 
 #include <pv/pvAccess.h>
 
@@ -66,6 +67,7 @@ private:
 
 class CAChannel :
     public Channel,
+    public tsDLNode<CAChannel>,
     public NotifierClient,
     public std::tr1::enable_shared_from_this<CAChannel>
 {

--- a/src/ca/caProvider.cpp
+++ b/src/ca/caProvider.cpp
@@ -32,8 +32,11 @@ CAChannelProvider::CAChannelProvider(const std::tr1::shared_ptr<Configuration> &
 CAChannelProvider::~CAChannelProvider()
 {
     epicsGuard<epicsMutex> G(channelListMutex);
-    while (CAChannel *ch = caChannelList.first()) {
-        ch->disconnectChannel();    // Removes itself from the list
+    while (CAChannel *ch = caChannelList.get()) {
+        // Here disconnectChannel() can't call our delChannel()
+        // beacuse its CAChannelProviderPtr has by now expired.
+        // That's why we removed it from caChannelList above.
+        ch->disconnectChannel();
     }
 }
 

--- a/src/ca/caProviderPvt.h
+++ b/src/ca/caProviderPvt.h
@@ -14,6 +14,7 @@
 
 #include <cadef.h>
 #include <epicsMutex.h>
+#include <tsDLList.h>
 
 #include <pv/logger.h>
 #include <pv/pvAccess.h>
@@ -80,7 +81,8 @@ public:
     virtual void flush();
     virtual void poll();
 
-    void addChannel(const CAChannelPtr & channel);
+    void addChannel(CAChannel &channel);
+    void delChannel(CAChannel &channel);
 
     CAContextPtr caContext() {
         return ca_context;
@@ -94,7 +96,7 @@ public:
 private:
     CAContextPtr ca_context;
     epicsMutex channelListMutex;
-    std::vector<CAChannelWPtr> caChannelList;
+    tsDLList<CAChannel> caChannelList;
 
     NotifierConveyor connectNotifier;
     NotifierConveyor resultNotifier;


### PR DESCRIPTION
This uses Jeff Hill's tsDLList implementation in the CA Provider to keep track of all the currently active CA Channel objects. I couldn't find a C++ standard container which didn't slow down the creation or deletion of channels or have unbounded memory issues (or require a garbage collection background thread). Maybe a `std::map` might have worked and been acceptable, but it would still have been slower than this.

Our user's application went from over 70 seconds to connect 60,000 PVs with EPICS 7.0.6 to under 3 with this version.