### PR TITLE
reset ostream flags when done

### DIFF
--- a/src/remote/abstractResponseHandler.cpp
+++ b/src/remote/abstractResponseHandler.cpp
@@ -40,7 +40,7 @@ void ResponseHandler::handleResponse(osiSockAddr* responseFrom,
         ipAddrToDottedIP(&responseFrom->ia, ipAddrStr, sizeof(ipAddrStr));
 
         std::ios::fmtflags initialflags = std::cerr.flags();
-        std::cerr<<"Message [0x"<<std::hex<<(int)command<<", v0x"
+        std::cerr<<"Message ["<<std::hex<<std::showbase<<(int)command<<", v"
                  <<int(version)<<"] received from "<<ipAddrStr<<" on "<<transport->getRemoteName()
                  <<" : "<<_description<<"\n"
                  <<HexDump(*payloadBuffer, payloadSize).limit(0xffff);

--- a/src/remote/abstractResponseHandler.cpp
+++ b/src/remote/abstractResponseHandler.cpp
@@ -39,10 +39,12 @@ void ResponseHandler::handleResponse(osiSockAddr* responseFrom,
         char ipAddrStr[24];
         ipAddrToDottedIP(&responseFrom->ia, ipAddrStr, sizeof(ipAddrStr));
 
-        std::cerr<<"Message [0x"<<std::hex<<(int)command<<", v0x"<<std::hex
+        std::ios::fmtflags initialflags = std::cerr.flags();
+        std::cerr<<"Message [0x"<<std::hex<<(int)command<<", v0x"
                  <<int(version)<<"] received from "<<ipAddrStr<<" on "<<transport->getRemoteName()
                  <<" : "<<_description<<"\n"
                  <<HexDump(*payloadBuffer, payloadSize).limit(0xffff);
+        std::cerr.flags(initialflags);
     }
 }
 }

--- a/src/remoteClient/clientContextImpl.cpp
+++ b/src/remoteClient/clientContextImpl.cpp
@@ -3000,8 +3000,10 @@ public:
         if (command < 0 || command >= (int8)m_handlerTable.size())
         {
             if(IS_LOGGABLE(logLevelError)) {
+                std::ios::fmtflags initialflags = std::cerr.flags();
                 std::cerr<<"Invalid (or unsupported) command: "<<std::hex<<(int)(0xFF&command)<<"\n"
                          <<HexDump(*payloadBuffer, payloadSize).limit(256u);
+                std::cerr.flags(initialflags);
             }
             return;
         }

--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -160,8 +160,10 @@ void ServerResponseHandler::handleResponse(osiSockAddr* responseFrom,
             "Invalid (or unsupported) command: %x.", (0xFF&command));
 
         if(IS_LOGGABLE(logLevelError)) {
+            std::ios::fmtflags initialflags = std::cerr.flags();
             std::cerr<<"Invalid (or unsupported) command: "<<std::hex<<(int)(0xFF&command)<<"\n"
                      <<HexDump(*payloadBuffer, payloadSize).limit(256u);
+            std::cerr.flags(initialflags);
         }
         return;
     }

--- a/src/utils/hexDump.cpp
+++ b/src/utils/hexDump.cpp
@@ -77,10 +77,12 @@ std::ostream& operator<<(std::ostream& strm, const HexDump& hex)
     if(len%hex._perLine)
         nlines++;
 
+    std::ios::fmtflags initialflags = strm.flags();
+    strm<<std::hex<<std::setfill('0');
     for(size_t l=0; l<nlines; l++)
     {
         size_t start = l*hex._perLine;
-        strm<<"0x"<<std::hex<<std::setw(addrwidth)<<std::setfill('0')<<start;
+        strm<<"0x"<<std::setw(addrwidth)<<start;
 
         // print hex chars
         for(size_t col=0; col<hex._perLine; col++)
@@ -89,7 +91,7 @@ std::ostream& operator<<(std::ostream& strm, const HexDump& hex)
                 strm<<' ';
             }
             if(start+col < len) {
-                strm<<std::hex<<std::setw(2)<<std::setfill('0')<<unsigned(hex.buf[start+col]&0xff);
+                strm<<std::setw(2)<<unsigned(hex.buf[start+col]&0xff);
             } else {
                 strm<<"  ";
             }
@@ -113,6 +115,7 @@ std::ostream& operator<<(std::ostream& strm, const HexDump& hex)
 
         strm<<'\n';
     }
+    strm.flags(initialflags);
 
     return strm;
 }


### PR DESCRIPTION
Fix for issue #177.
Always reset `flags()` when leaving a function that modifies them.
Also, setting `hex` or `setfill()` once is enough.