### PR TITLE
avoid dangling pointer when indexvalue does out of scope

### DIFF
--- a/src/ca/dbdToPv.cpp
+++ b/src/ca/dbdToPv.cpp
@@ -840,6 +840,7 @@ Status DbdToPv::putToDBD(
     char *ca_stringBuffer(0);
     dbr_char_t   bvalue(0);
     dbr_short_t  svalue(0);
+    dbr_enum_t   evalue(0);
     dbr_long_t   lvalue(0);
     dbr_float_t  fvalue(0);
     dbr_double_t dvalue(0);
@@ -944,8 +945,7 @@ Status DbdToPv::putToDBD(
            case DBR_ENUM:
            {
                GET_SUBFIELD_WITH_ERROR_CHECK(PVInt, pvValue, pvStructure, "value.index", "DbdToPv::putToDBD logic error");
-               dbr_enum_t indexvalue = pvValue->get();
-               pValue = &indexvalue;
+               pValue = put_DBRScalar<dbr_enum_t,PVUShort>(&evalue,pvValue);
                break;
            }
            case DBR_STRING: 


### PR DESCRIPTION
The problem shows up on macOS but not on Linux and Windows as I checked.

With caProvider, the value will not change.
```
% pvput -p ca catest.SCAN 1
Old : 2022-02-19 15:25:35.846  MINOR DEVICE HIGH (0) Passive
New : 2022-02-19 15:25:35.846  MINOR DEVICE HIGH (0) Passive
```
With pvaProvider, the value is changed.
```
% pvput -p pva catest.SCAN 1
Old : 2022-02-19 15:25:35.846  MINOR DEVICE HIGH (0) Passive
New : 2022-02-19 15:25:35.846  MINOR DEVICE HIGH (1) Event
```