### PR TITLE
Fix crash when toEcho is empty

### DIFF
--- a/src/server/pv/responseHandlers.h
+++ b/src/server/pv/responseHandlers.h
@@ -96,7 +96,7 @@ public:
     EchoTransportSender(osiSockAddr* echoFrom, size_t payloadSize, epics::pvData::ByteBuffer& payloadBuffer) {
         memcpy(&_echoFrom, echoFrom, sizeof(osiSockAddr));
         toEcho.resize(payloadSize);
-        payloadBuffer.getArray(&toEcho[0], payloadSize);
+        payloadBuffer.getArray(toEcho.data(), payloadSize);
     }
 
     virtual ~EchoTransportSender() {}
@@ -104,7 +104,7 @@ public:
     virtual void send(epics::pvData::ByteBuffer* buffer, TransportSendControl* control) OVERRIDE FINAL {
         control->startMessage(CMD_ECHO, toEcho.size(), toEcho.size());
         control->setRecipient(_echoFrom);
-        buffer->putArray<char>(&toEcho[0], toEcho.size());
+        buffer->putArray<char>(toEcho.data(), toEcho.size());
     }
 
 private:

--- a/src/server/pv/responseHandlers.h
+++ b/src/server/pv/responseHandlers.h
@@ -96,7 +96,9 @@ public:
     EchoTransportSender(osiSockAddr* echoFrom, size_t payloadSize, epics::pvData::ByteBuffer& payloadBuffer) {
         memcpy(&_echoFrom, echoFrom, sizeof(osiSockAddr));
         toEcho.resize(payloadSize);
-        payloadBuffer.getArray(toEcho.data(), payloadSize);
+        if (payloadSize) {
+            payloadBuffer.getArray(&toEcho[0], payloadSize);
+        }
     }
 
     virtual ~EchoTransportSender() {}
@@ -104,7 +106,9 @@ public:
     virtual void send(epics::pvData::ByteBuffer* buffer, TransportSendControl* control) OVERRIDE FINAL {
         control->startMessage(CMD_ECHO, toEcho.size(), toEcho.size());
         control->setRecipient(_echoFrom);
-        buffer->putArray<char>(toEcho.data(), toEcho.size());
+        if (toEcho.size() > 0) {
+            buffer->putArray<char>(&toEcho[0], toEcho.size());
+        }
     }
 
 private:


### PR DESCRIPTION
I had some repeatable crashes locally on windows x64 with a debug build until I applied this fix, but having just reverted the fix to get a stack trace to post now I don't seem to be able to reproduce it. Just posting fix here in case it might be something worth applying anyway.    