### PR TITLE
Set PVAS_SERVER_PORT

### DIFF
--- a/src/ioc/PVAServerRegister.cpp
+++ b/src/ioc/PVAServerRegister.cpp
@@ -52,6 +52,12 @@ void startitup() {
                                                     // from environment
                                                     .push_env()
                                                     .build()));
+
+    unsigned short port = the_server->getServerPort();
+    char pbuf[7];
+    epicsSnprintf(pbuf, sizeof(pbuf)-1, "%u", port);
+    pbuf[sizeof(pbuf)-1] = '\0';
+    epicsEnvSet("PVAS_SERVER_PORT", pbuf);
 }
 
 void startPVAServer(const char *names)


### PR DESCRIPTION
Sets `$PVAS_SERVER_PORT` for use with recceiver.

Note that this would also set `$PVAS_SERVER_PORT` each time a server is restarted, potentially with a different port.  Currently, there is no good way to notify reccaster of this change.