### PR TITLE
UDP Sender Port

### DIFF
--- a/src/pva/pv/pvaConstants.h
+++ b/src/pva/pv/pvaConstants.h
@@ -43,6 +43,9 @@ const epics::pvData::int32 PVA_SERVER_PORT = 5075;
 /** Default PVA beacon port. */
 const epics::pvData::int32 PVA_BROADCAST_PORT = 5076;
 
+/** Default UDP sender port. */
+const epics::pvData::int32 PVA_UDP_SENDER_PORT = 0;
+
 /** PVA protocol message header size. */
 const epics::pvData::int16 PVA_MESSAGE_HEADER_SIZE = 8;
 

--- a/src/remote/blockingUDPTransport.cpp
+++ b/src/remote/blockingUDPTransport.cpp
@@ -580,6 +580,7 @@ void initializeUDPTransports(bool serverFlag,
                              const ResponseHandler::shared_pointer& responseHandler,
                              BlockingUDPTransport::shared_pointer& sendTransport,
                              int32& listenPort,
+                             int32& senderPort,
                              bool autoAddressList,
                              const std::string& addressList,
                              const std::string& ignoreAddressList)
@@ -595,7 +596,7 @@ void initializeUDPTransports(bool serverFlag,
     osiSockAddr anyAddress;
     memset(&anyAddress, 0, sizeof(anyAddress));
     anyAddress.ia.sin_family = AF_INET;
-    anyAddress.ia.sin_port = htons(0);
+    anyAddress.ia.sin_port = htons(senderPort);
     anyAddress.ia.sin_addr.s_addr = htonl(INADDR_ANY);
 
     sendTransport = connector.connect(responseHandler, anyAddress, protoVer);

--- a/src/remote/pv/blockingUDP.h
+++ b/src/remote/pv/blockingUDP.h
@@ -401,6 +401,7 @@ void initializeUDPTransports(
     const ResponseHandler::shared_pointer& responseHandler,
     BlockingUDPTransport::shared_pointer& sendTransport,
     epics::pvData::int32& listenPort,
+    epics::pvData::int32& senderPort,
     bool autoAddressList,
     const std::string& addressList,
     const std::string& ignoreAddressList);

--- a/src/remoteClient/clientContextImpl.cpp
+++ b/src/remoteClient/clientContextImpl.cpp
@@ -4022,6 +4022,7 @@ public:
         out << "CONNECTION_TIMEOUT : " << m_connectionTimeout << std::endl;
         out << "BEACON_PERIOD      : " << m_beaconPeriod << std::endl;
         out << "BROADCAST_PORT     : " << m_broadcastPort << std::endl;;
+        out << "UDP_SENDER_PORT    : " << m_senderPort << std::endl;;
         out << "RCV_BUFFER_SIZE    : " << m_receiveBufferSize << std::endl;
         out << "STATE              : ";
         switch (m_contextState)
@@ -4114,6 +4115,7 @@ private:
         m_connectionTimeout = m_configuration->getPropertyAsFloat("EPICS_PVA_CONN_TMO", m_connectionTimeout);
         m_beaconPeriod = m_configuration->getPropertyAsFloat("EPICS_PVA_BEACON_PERIOD", m_beaconPeriod);
         m_broadcastPort = m_configuration->getPropertyAsInteger("EPICS_PVA_BROADCAST_PORT", m_broadcastPort);
+        m_senderPort = m_configuration->getPropertyAsInteger("EPICS_PVA_UDP_SENDER_PORT", m_senderPort);
         m_receiveBufferSize = m_configuration->getPropertyAsInteger("EPICS_PVA_MAX_ARRAY_BYTES", m_receiveBufferSize);
     }
 
@@ -4150,7 +4152,7 @@ private:
             epicsSocketDestroy (socket);
 
             initializeUDPTransports(false, m_udpTransports, ifaceList, m_responseHandler, m_searchTransport,
-                                    m_broadcastPort, m_autoAddressList, m_addressList, std::string());
+                                    m_broadcastPort, m_senderPort, m_autoAddressList, m_addressList, std::string());
 
         }
 
@@ -4447,6 +4449,11 @@ private:
      * Broadcast (beacon, search) port number to listen to.
      */
     int32 m_broadcastPort;
+
+    /**
+     * UDP sender port
+     */
+    int32 m_senderPort;
 
     /**
      * Receive buffer size (max size of payload).

--- a/src/server/pv/serverContext.h
+++ b/src/server/pv/serverContext.h
@@ -82,6 +82,12 @@ public:
      */
     virtual epics::pvData::int32 getBroadcastPort() = 0;
 
+    /**
+     * Get UDP sender port.
+     * @return UDP sender port.
+     */
+    virtual epics::pvData::int32 getSenderPort() = 0;
+
     /** Return a Configuration with the actual values being used,
      *  including defaults used, and bounds limits applied.
      */

--- a/src/server/pv/serverContextImpl.h
+++ b/src/server/pv/serverContextImpl.h
@@ -89,6 +89,12 @@ public:
     epics::pvData::int32 getBroadcastPort() OVERRIDE FINAL;
 
     /**
+     * Get UDP sender port.
+     * @return UDP sender port.
+     */
+    epics::pvData::int32 getSenderPort() OVERRIDE FINAL;
+
+    /**
      * Get registered beacon server status provider.
      * @return registered beacon server status provider.
      */
@@ -161,6 +167,11 @@ private:
      * Broadcast port number to listen to.
      */
     epics::pvData::int32 _broadcastPort;
+
+    /**
+     * UDP sender port.
+     */
+    epics::pvData::int32 _senderPort;
 
     /**
      * Port number for the server to listen to.

--- a/src/server/serverContext.cpp
+++ b/src/server/serverContext.cpp
@@ -37,6 +37,7 @@ ServerContextImpl::ServerContextImpl():
     _autoBeaconAddressList(true),
     _beaconPeriod(15.0),
     _broadcastPort(PVA_BROADCAST_PORT),
+    _senderPort(PVA_UDP_SENDER_PORT),
     _serverPort(PVA_SERVER_PORT),
     _receiveBufferSize(MAX_TCP_RECV),
     _timer(new Timer("PVAS timers", lowerPriority)),
@@ -142,6 +143,8 @@ void ServerContextImpl::loadConfiguration()
 
     _broadcastPort = config->getPropertyAsInteger("EPICS_PVA_BROADCAST_PORT", _broadcastPort);
     _broadcastPort = config->getPropertyAsInteger("EPICS_PVAS_BROADCAST_PORT", _broadcastPort);
+    _senderPort = config->getPropertyAsInteger("EPICS_PVA_UDP_SENDER_PORT", _senderPort);
+    _senderPort = config->getPropertyAsInteger("EPICS_PVAS_UDP_SENDER_PORT", _senderPort);
 
     _receiveBufferSize = config->getPropertyAsInteger("EPICS_PVA_MAX_ARRAY_BYTES", _receiveBufferSize);
     _receiveBufferSize = config->getPropertyAsInteger("EPICS_PVAS_MAX_ARRAY_BYTES", _receiveBufferSize);
@@ -246,6 +249,9 @@ ServerContextImpl::getCurrentConfig()
     SET("EPICS_PVAS_BROADCAST_PORT", getBroadcastPort());
     SET("EPICS_PVA_BROADCAST_PORT", getBroadcastPort());
 
+    SET("EPICS_PVAS_UDP_SENDER_PORT", getSenderPort());
+    SET("EPICS_PVA_UDP_SENDER_PORT", getSenderPort());
+
     SET("EPICS_PVAS_MAX_ARRAY_BYTES", getReceiveBufferSize());
     SET("EPICS_PVA_MAX_ARRAY_BYTES", getReceiveBufferSize());
 
@@ -278,7 +284,7 @@ void ServerContextImpl::initialize()
 
     // setup broadcast UDP transport
     initializeUDPTransports(true, _udpTransports, _ifaceList, _responseHandler, _broadcastTransport,
-                            _broadcastPort, _autoBeaconAddressList, _beaconAddressList, _ignoreAddressList);
+                            _broadcastPort, _senderPort, _autoBeaconAddressList, _beaconAddressList, _ignoreAddressList);
 
     _beaconEmitter.reset(new BeaconEmitter("tcp", _broadcastTransport, thisServerContext));
 
@@ -380,6 +386,7 @@ void ServerContextImpl::printInfo(ostream& str, int lvl)
         SHOW(EPICS_PVAS_AUTO_BEACON_ADDR_LIST)
         SHOW(EPICS_PVAS_BEACON_PERIOD)
         SHOW(EPICS_PVAS_BROADCAST_PORT)
+        SHOW(EPICS_PVAS_UDP_SENDER_PORT)
         SHOW(EPICS_PVAS_SERVER_PORT)
         SHOW(EPICS_PVAS_PROVIDER_NAMES)
 #undef SHOW
@@ -483,6 +490,11 @@ int32 ServerContextImpl::getServerPort()
 int32 ServerContextImpl::getBroadcastPort()
 {
     return _broadcastPort;
+}
+
+int32 ServerContextImpl::getSenderPort()
+{
+    return _senderPort;
 }
 
 BeaconServerStatusProvider::shared_pointer ServerContextImpl::getBeaconServerStatusProvider()


### PR DESCRIPTION
This PR allows control of UDP sender port on both client and server side via the EPICS_PVA_UDP_SENDER_PORT environment variable. If this is not set, the behavior on both client and server side is as before, with random port assigned for UDP sender messages.

Closes https://github.com/epics-base/pvAccessCPP/issues/159 .