### PR TITLE
add default message for pvget

### DIFF
--- a/pvtoolsSrc/pvget.cpp
+++ b/pvtoolsSrc/pvget.cpp
@@ -276,6 +276,12 @@ int MAIN (int argc, char *argv[])
 
         // ================ Parse Arguments
 
+        if(argc <= optind){
+            /* No arguments specified */
+            fprintf(stderr, "No arguments specified. Please use " EXECNAME" -h for help");
+            return 1;
+        }
+
         while ((opt = getopt(argc, argv, ":hvVRM:r:w:tmp:qdcF:f:ni")) != -1) {
             switch (opt) {
             case 'h':               /* Print usage */
@@ -361,6 +367,9 @@ int MAIN (int argc, char *argv[])
                         optopt);
                 return 1;
             default :
+                fprintf(stderr,
+                        "Option '-%c' is not supported - it is a valid option but is not implemented. \n",
+                        optopt);
                 usage();
                 return 1;
             }


### PR DESCRIPTION
Adds a default message for pvget. I don't know if line 363 (the default case) was a bug as i could never get it to run.  @ralphlange I found this after I showed you my (accidentally?) working PVAccess. 

Maybe there's a good reason that pvget doesn't have this line but the other tools do, please let me know!
