### PR TITLE
fix false warning by gcc version 12 only

### DIFF
--- a/src/ioc/Makefile
+++ b/src/ioc/Makefile
@@ -20,4 +20,8 @@ pvAccessIOC_SRCS += PVAServerRegister.cpp
 pvAccessIOC_SRCS += PVAClientRegister.cpp
 pvAccessIOC_SRCS += reftrackioc.cpp
 
+# fix false (?) warning by gcc 12 only
+reftrackioc_CPPFLAGS += $(reftrackioc_CPPFLAGS_GCC-$(GCC_MAJOR))
+reftrackioc_CPPFLAGS_GCC-12 = -Wno-dangling-pointer
+
 include $(TOP)/configure/RULES


### PR DESCRIPTION
Fix false (?) warning in
https://github.com/epics-base/pvAccessCPP/blob/1492b3d5af0a17802a8c904947a62578190af54e/src/ioc/reftrackioc.cpp#L51-L59

```
In file included from /usr/include/c++/12/map:60,
                 from epics-base-7.0/include/pv/reftrack.h:42,
                 from ../reftrackioc.cpp:11:
In member function ‘void std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::swap(std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>&) [with _Key = std::__cxx11::basic_string<char>; _Val = std::pair<const std::__cxx11::basic_string<char>, epics::RefSnapshot::Count>; _KeyOfValue = std::_Select1st<std::pair<const std::__cxx11::basic_string<char>, epics::RefSnapshot::Count> >; _Compare = std::less<std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::__cxx11::basic_string<char>, epics::RefSnapshot::Count> >]’,
    inlined from ‘void std::map<_Key, _Tp, _Compare, _Alloc>::swap(std::map<_Key, _Tp, _Compare, _Alloc>&) [with _Key = std::__cxx11::basic_string<char>; _Tp = epics::RefSnapshot::Count; _Compare = std::less<std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::__cxx11::basic_string<char>, epics::RefSnapshot::Count> >]’ at /usr/include/c++/12/bits/stl_map.h:1172:18,
    inlined from ‘void epics::RefSnapshot::swap(epics::RefSnapshot&)’ at epics-base-7.0/include/pv/reftrack.h:105:20,
    inlined from ‘void {anonymous}::refsave()’ at ../reftrackioc.cpp:57:23,
    inlined from ‘void epics::detail::call0(const iocshArgBuf*) [with void (* fn)() = {anonymous}::refsave]’ at ../reftrackioc.cpp:87:26:
/usr/include/c++/12/bits/stl_tree.h:2091:36: warning: storing the address of local variable ‘snap’ in ‘*MEM[(struct _Rb_tree_node_base * &)&snap + 16].std::_Rb_tree_node_base::_M_parent’ [-Wdangling-pointer=]
 2091 |           __t._M_root()->_M_parent = __t._M_end();
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
../reftrackioc.cpp: In function ‘void epics::detail::call0(const iocshArgBuf*) [with void (* fn)() = {anonymous}::refsave]’:
../reftrackioc.cpp:54:28: note: ‘snap’ declared here
   54 |         epics::RefSnapshot snap;
      |                            ^~~~
../reftrackioc.cpp:54:28: note: ‘snap.epics::RefSnapshot::counts.std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, epics::RefSnapshot::Count, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, epics::RefSnapshot::Count> > >::_M_t.std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, epics::RefSnapshot::Count>, std::_Select1st<std::pair<const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, epics::RefSnapshot::Count> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, epics::RefSnapshot::Count> > >::_M_impl.std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, epics::RefSnapshot::Count>, std::_Select1st<std::pair<const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, epics::RefSnapshot::Count> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, epics::RefSnapshot::Count> > >::_Rb_tree_impl<std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, true>::<unnamed>.std::_Rb_tree_header::_M_header.std::_Rb_tree_node_base::_M_parent’ declared here
```
It seems gcc 12 does not like the fact that `savedSnap.swap(snap)` references a local variable (`snap`).
Other c++11 capable gcc versions (tested 8 ... 14) do not show a warning here. Neither does clang or MSVC.
