### PR TITLE
Fix MSVC warning C4275

### DIFF
--- a/src/remote/pv/remote.h
+++ b/src/remote/pv/remote.h
@@ -119,7 +119,7 @@ void hackAroundRTEMSSocketInterrupt();
 /**
  * Interface defining transport send control.
  */
-class TransportSendControl : public epics::pvData::SerializableControl {
+class epicsShareClass TransportSendControl : public epics::pvData::SerializableControl {
 public:
     POINTER_DEFINITIONS(TransportSendControl);
 

--- a/src/rpcService/pv/rpcService.h
+++ b/src/rpcService/pv/rpcService.h
@@ -29,7 +29,7 @@
 namespace epics {
 namespace pvAccess {
 
-class epicsShareClass RPCRequestException : public std::runtime_error {
+class RPCRequestException : public std::runtime_error {
 public:
 
     explicit RPCRequestException(std::string const & message) :

--- a/src/utils/pv/destroyable.h
+++ b/src/utils/pv/destroyable.h
@@ -21,7 +21,7 @@ namespace epics { namespace pvAccess {
         /**
          * @brief Instance declaring destroy method.
          */
-        class Destroyable {
+        class epicsShareClass Destroyable {
         public:
             POINTER_DEFINITIONS(Destroyable);
             /**


### PR DESCRIPTION
MSVC warnings: non - DLL-interface class 'class_1' used as base for DLL-interface class 'class_2'

Fixes:
 * Make base classs`Destroyable` and `TransportSendControl` DLL-interface classes
 * Make `RPCRequestException` a non-DLL-interface class (does not need to be and should not be one if fully defined in header file, i.e. has no methods in *.cpp which would end up in the DLL)
