### PR TITLE
Fix MSVC warning C4390

### DIFF
--- a/src/rpcClient/rpcClient.cpp
+++ b/src/rpcClient/rpcClient.cpp
@@ -23,7 +23,7 @@
 #if 0
 #  define TRACE(msg) std::cerr<<"TRACE: "<<CURRENT_FUNCTION<<" : "<< msg <<"\n"
 #else
-#  define TRACE(msg)
+#  define TRACE(msg) while(0){}
 #endif
 
 namespace pvd = epics::pvData;


### PR DESCRIPTION
';' : empty controlled statement found; is this the intent?

In this case, it is indeed the intent.