### PR TITLE
Fix MSVC warning C4309

### DIFF
--- a/src/pva/pv/pvaConstants.h
+++ b/src/pva/pv/pvaConstants.h
@@ -73,7 +73,7 @@ const epics::pvData::int16 PVA_DEFAULT_PRIORITY = 0;
 const epics::pvData::uint32 MAX_CHANNEL_NAME_LENGTH = 500;
 
 /** Invalid data type. */
-const epics::pvData::int16 INVALID_DATA_TYPE = 0xFFFF;
+const epics::pvData::int16 INVALID_DATA_TYPE = -1;
 
 /** Invalid IOID. */
 const epics::pvData::int32 INVALID_IOID = 0;

--- a/src/utils/inetAddressUtil.cpp
+++ b/src/utils/inetAddressUtil.cpp
@@ -38,7 +38,7 @@ void encodeAsIPv6Address(ByteBuffer* buffer, const osiSockAddr* address) {
     buffer->putLong(0);
     buffer->putShort(0);
     // next 16-bits are 1
-    buffer->putShort(0xFFFF);
+    buffer->putShort(-1);
     // following IPv4 address in big-endian (network) byte order
     uint32_t ipv4Addr = ntohl(address->ia.sin_addr.s_addr);
     buffer->putByte((int8)((ipv4Addr>>24)&0xFF));


### PR DESCRIPTION
truncation of constant value

The value 0xFFFF does not fit a signed 16 bit integer. Use -1 instead.

Also fixes #211.
