### PR TITLE
Silence warnings about using deprecated pvData functions

### DIFF
--- a/testApp/remote/channelAccessIFTest.cpp
+++ b/testApp/remote/channelAccessIFTest.cpp
@@ -1,6 +1,9 @@
 // disable buggy boost enable_shared_from_this assert code
 #define BOOST_DISABLE_ASSERTS
 
+// Disable warnings about using deprecated functions from pvData
+#define PVD_INTERNAL
+
 #include <stdlib.h>
 #include <time.h>
 #include <vector>

--- a/testApp/remote/testServer.cpp
+++ b/testApp/remote/testServer.cpp
@@ -5,6 +5,9 @@
 // disable buggy boost enable_shared_from_this assert code
 #define BOOST_DISABLE_ASSERTS
 
+// Disable warnings about using deprecated functions from pvData
+#define PVD_INTERNAL
+
 #include <pv/serverContext.h>
 #include <pv/clientContextImpl.h>
 #include <epicsExit.h>


### PR DESCRIPTION
Silences the warnings mentioned in PR #206.

Remove the `PVD_INTERNAL` macro after fixing the function use.


