### PR TITLE
Fix build errors and warnings from #184 

### DIFF
--- a/src/remote/pv/beaconHandler.h
+++ b/src/remote/pv/beaconHandler.h
@@ -29,11 +29,13 @@
 namespace 
 {
     class InternalClientContextImpl;
-    class BeaconCleanupHandler;
 }
 
 namespace epics {
 namespace pvAccess {
+namespace detail {
+    class BeaconCleanupHandler;
+}
 
 /**
  * BeaconHandler
@@ -94,7 +96,7 @@ private:
     /**
      * Callback for cleaning up the beacon
      */
-    std::tr1::shared_ptr<BeaconCleanupHandler> _callback;
+    std::tr1::shared_ptr<detail::BeaconCleanupHandler> _callback;
 
     /**
      * Update beacon.


### PR DESCRIPTION
Fixes a couple of oopses in #184. I mistakenly used C++11 constructs (nullptr, std::shared_ptr) which breaks older compilers.

There was also a warning due to linkage type mismatch in the `BeaconHandler`, so I've moved `BeaconCleanupHandler` to a non-anonymous `detail` namespace