### PR TITLE
Add -S option to pvget/pvmonitor to stringify byte arrays

### DIFF
--- a/pvtoolsSrc/pvget.cpp
+++ b/pvtoolsSrc/pvget.cpp
@@ -39,6 +39,8 @@ namespace {
 
 size_t pvnamewidth;
 
+bool stringify = false;
+
 int haderror;
 
 void usage (void)
@@ -46,6 +48,7 @@ void usage (void)
     fprintf (stderr, "\nUsage: " EXECNAME " [options] <PV name>...\n"
              "\n"
              COMMON_OPTIONS
+             "  -S:                Print array of bytes as a string\n"
              " deprecated options:\n"
              "  -q, -t, -i, -n, -F: ignored\n"
              "  -f <input file>:   errors\n"
@@ -85,6 +88,7 @@ struct Getter : public pvac::ClientChannel::GetCallback, public Tracker
             pvd::PVStructure::Formatter fmt(event.value->stream()
                                             .format(outmode));
 
+            fmt.asString(stringify);
             if(verbosity>=2)
                 fmt.highlight(*event.valid); // show all, highlight valid
             else
@@ -276,7 +280,7 @@ int MAIN (int argc, char *argv[])
 
         // ================ Parse Arguments
 
-        while ((opt = getopt(argc, argv, ":hvVRM:r:w:tmp:qdcF:f:ni")) != -1) {
+        while ((opt = getopt(argc, argv, ":hvVRM:r:w:tmp:qdcF:f:niS")) != -1) {
             switch (opt) {
             case 'h':               /* Print usage */
                 usage();
@@ -335,6 +339,9 @@ int MAIN (int argc, char *argv[])
             case 'n':
             case 'q':               /* Quiet mode */
                 // deprecate
+                break;
+            case 'S':
+                stringify = true;   /* Stringify byte scalar arrays */
                 break;
             case 'f':               /* Use input stream as input */
                 fprintf(stderr, "Unsupported option -f\n");

--- a/pvtoolsSrc/pvget.cpp
+++ b/pvtoolsSrc/pvget.cpp
@@ -39,6 +39,8 @@ namespace {
 
 size_t pvnamewidth;
 
+bool stringify = false;
+
 int haderror;
 
 void usage (void)
@@ -46,6 +48,7 @@ void usage (void)
     fprintf (stderr, "\nUsage: " EXECNAME " [options] <PV name>...\n"
              "\n"
              COMMON_OPTIONS
+             "  -S:                Print array of bytes as a string\n"
              " deprecated options:\n"
              "  -q, -t, -i, -n, -F: ignored\n"
              "  -f <input file>:   errors\n"
@@ -85,6 +88,7 @@ struct Getter : public pvac::ClientChannel::GetCallback, public Tracker
             pvd::PVStructure::Formatter fmt(event.value->stream()
                                             .format(outmode));
 
+            fmt.arrayAsString(stringify);
             if(verbosity>=2)
                 fmt.highlight(*event.valid); // show all, highlight valid
             else
@@ -276,7 +280,7 @@ int MAIN (int argc, char *argv[])
 
         // ================ Parse Arguments
 
-        while ((opt = getopt(argc, argv, ":hvVRM:r:w:tmp:qdcF:f:ni")) != -1) {
+        while ((opt = getopt(argc, argv, ":hvVRM:r:w:tmp:qdcF:f:niS")) != -1) {
             switch (opt) {
             case 'h':               /* Print usage */
                 usage();
@@ -335,6 +339,9 @@ int MAIN (int argc, char *argv[])
             case 'n':
             case 'q':               /* Quiet mode */
                 // deprecate
+                break;
+            case 'S':
+                stringify = true;   /* Stringify byte scalar arrays */
                 break;
             case 'f':               /* Use input stream as input */
                 fprintf(stderr, "Unsupported option -f\n");


### PR DESCRIPTION
This emulates the behavior of the caget -S option. Byte arrays are displayed as strings.

Example (without -S):
```
$ pvget SIOC:TST:SYS0:APP_DIR
SIOC:TST:SYS0:APP_DIR 2026-03-17 23:09:56.242  [47,109,101,100,105,97,47,66,105,103,68,114,105,118,101,47,80,114,111,106,101,99,116,115,47,101,112,105,99,115,47,105,111,99,47,97,116,108,97,115,45,103,105,116,47,105,111,99,66,111,111,116,47,115,105,111,99,45,116,115,116,45,115,121,115,48,0]
```

Example (with -S):
```
$ pvget -S SIOC:TST:SYS0:APP_DIR
SIOC:TST:SYS0:APP_DIR 2026-03-17 22:39:05.669  /media/BigDrive/Projects/epics/ioc/atlas-git/iocBoot/sioc-tst-sys0
```

pvData PR: https://github.com/epics-base/pvDataCPP/pull/105