### PR TITLE
Potential fix for testChannelAccess tests

### DIFF
--- a/testApp/remote/syncTestRequesters.h
+++ b/testApp/remote/syncTestRequesters.h
@@ -1211,6 +1211,10 @@ public:
         }
 
         resetEvent();
+        {
+            Lock lock(m_pointerMutex);
+            m_putArrayStatus = false;
+        }
         if (lastRequest)
             m_channelArray->lastRequest();
         // TODO stride !!!
@@ -1227,6 +1231,10 @@ public:
         }
 
         resetEvent();
+        {
+            Lock lock(m_pointerMutex);
+            m_getArrayStatus = false;
+        }
         if (lastRequest)
             m_channelArray->lastRequest();
         // TODO stride !!!
@@ -1243,6 +1251,10 @@ public:
         }
 
         resetEvent();
+        {
+            Lock lock(m_pointerMutex);
+            m_lengthArrayStatus = false;
+        }
         if (lastRequest)
             m_channelArray->lastRequest();
         m_channelArray->setLength(length);
@@ -1257,6 +1269,10 @@ public:
         }
 
         resetEvent();
+        {
+            Lock lock(m_pointerMutex);
+            m_lengthArrayStatus = false;
+        }
         if (lastRequest)
             m_channelArray->lastRequest();
         m_channelArray->getLength();
@@ -1381,12 +1397,6 @@ private:
 
     bool waitUntilGetArrayDone(double timeOut)
     {
-        {
-            Lock lock(m_pointerMutex);
-            m_getArrayStatus = false;
-        }
-
-
         bool signaled = waitUntilEvent(timeOut);
         if (!signaled) {
             return false;
@@ -1399,12 +1409,6 @@ private:
 
     bool waitUntilPutArrayDone(double timeOut)
     {
-        {
-            Lock lock(m_pointerMutex);
-            m_putArrayStatus = false;
-        }
-
-
         bool signaled = waitUntilEvent(timeOut);
         if (!signaled) {
             return false;
@@ -1417,12 +1421,6 @@ private:
 
     bool waitUntilSetLengthDone(double timeOut)
     {
-        {
-            Lock lock(m_pointerMutex);
-            m_lengthArrayStatus = false;
-        }
-
-
         bool signaled = waitUntilEvent(timeOut);
         if (!signaled) {
             return false;


### PR DESCRIPTION
Bug analysis and fix developed by Claude Opus 4.6:

  Root cause: A race condition in SyncChannelArrayRequesterImpl in
  syncTestRequesters.h:1382-1433. The waitUntilGetArrayDone (and
  Put/SetLength variants) reset their status flag to false after the
  async request was already sent. If the callback fires before the
  reset (common on a single-CPU system where the test thread gets
  preempted), the callback's true status is overwritten, and the test
  reports a spurious failure despite the operation succeeding.

  Fix: Moved the status reset from the waitUntil*Done methods into the
  sync* methods, before the async call is sent, to match the pattern
  used by the other requester classes in the file
  (SyncChannelGetRequesterImpl, SyncChannelPutRequesterImpl, etc.).