### PR TITLE
Add protection against some network issues

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -206,7 +206,8 @@ void ClientChannel::removeConnectListener(ConnectCallback* cb)
 void ClientChannel::show(std::ostream& strm) const
 {
     if(impl) {
-        strm<<typeid(*impl->channel.get()).name()<<" : ";
+        pva::Channel& channel = *impl->channel;
+        strm<<typeid(channel).name()<<" : ";
         impl->channel->printInfo(strm);
     } else {
         strm<<"NULL Channel";
@@ -346,8 +347,9 @@ void ClientProvider::disconnect()
 ::std::ostream& operator<<(::std::ostream& strm, const ClientChannel& op)
 {
     if(op.impl) {
+        pva::Channel& channel = *op.impl->channel;
         strm << "ClientChannel("
-             << typeid(*op.impl->channel.get()).name()<<", "
+             << typeid(channel).name()<<", "
                 "\"" << op.impl->channel->getChannelName() <<"\", "
                 "\"" << op.impl->channel->getProvider()->getProviderName() <<"\", "
                 "connected="<<(op.impl->channel->isConnected()?"true":"false")
@@ -361,8 +363,9 @@ void ClientProvider::disconnect()
 ::std::ostream& operator<<(::std::ostream& strm, const ClientProvider& op)
 {
     if(op.impl) {
+        pva::ChannelProvider& provider = *op.impl->provider;
         strm << "ClientProvider("
-             << typeid(*op.impl->provider.get()).name()<<", "
+             << typeid(provider).name()<<", "
                 "\""<<op.impl->provider->getProviderName()<<"\")";
     } else {
         strm << "ClientProvider()";

--- a/src/pipelineService/pipelineService.cpp
+++ b/src/pipelineService/pipelineService.cpp
@@ -6,3 +6,15 @@
 
 #define epicsExportSharedSymbols
 #include <pv/pipelineService.h>
+
+namespace epics {
+namespace pvAccess {
+
+// Out-of-line destructors anchor each interface's vtable and type_info
+// to this translation unit.
+PipelineControl::~PipelineControl() {}
+PipelineSession::~PipelineSession() {}
+PipelineService::~PipelineService() {}
+
+}
+}

--- a/src/pipelineService/pv/pipelineService.h
+++ b/src/pipelineService/pv/pipelineService.h
@@ -34,7 +34,7 @@ class epicsShareClass PipelineControl
 public:
     POINTER_DEFINITIONS(PipelineControl);
 
-    virtual ~PipelineControl() {};
+    virtual ~PipelineControl();
 
     /// Number of free elements in the local queue.
     /// A service can (should) full up the entire queue.
@@ -64,7 +64,7 @@ class epicsShareClass PipelineSession
 public:
     POINTER_DEFINITIONS(PipelineSession);
 
-    virtual ~PipelineSession() {};
+    virtual ~PipelineSession();
 
     /// Returns (minimum) local queue size.
     /// Actual local queue size = max( getMinQueueSize(), client queue size );
@@ -88,7 +88,7 @@ class epicsShareClass PipelineService
 public:
     POINTER_DEFINITIONS(PipelineService);
 
-    virtual ~PipelineService() {};
+    virtual ~PipelineService();
 
     virtual PipelineSession::shared_pointer createPipeline(
         epics::pvData::PVStructure::shared_pointer const & pvRequest

--- a/src/remote/blockingUDPTransport.cpp
+++ b/src/remote/blockingUDPTransport.cpp
@@ -369,6 +369,10 @@ bool BlockingUDPTransport::processBuffer(Transport::shared_pointer const & trans
         if (flags & 0x01)
             continue;
 
+        // reject negative payload size (sign-extends to a huge size_t)
+        if (static_cast<int32>(payloadSize) < 0)
+            return false;
+
         size_t nextRequestPosition = receiveBuffer->getPosition() + payloadSize;
 
         // payload size check

--- a/src/remote/codec.cpp
+++ b/src/remote/codec.cpp
@@ -242,6 +242,13 @@ void AbstractCodec::processReadNormal()  {
                         "not-a-first segmented message received in normal mode");
                 }
 
+                // reject negative payload size (sign-extends to a huge size_t)
+                if (_payloadSize < 0)
+                {
+                    invalidDataStreamHandler();
+                    throw invalid_data_stream_exception("negative payload size");
+                }
+
                 _storedPayloadSize = _payloadSize;
                 _storedPosition = _socketBuffer.getPosition();
                 _storedLimit = _socketBuffer.getLimit();
@@ -363,6 +370,13 @@ void AbstractCodec::processReadSegmented() {
                 invalidDataStreamHandler();
                 throw invalid_data_stream_exception(
                     "not-a-first segmented message expected");
+            }
+
+            // reject negative payload size (sign-extends to a huge size_t)
+            if (_payloadSize < 0)
+            {
+                invalidDataStreamHandler();
+                throw invalid_data_stream_exception("negative payload size");
             }
 
             _storedPayloadSize = _payloadSize;

--- a/src/remote/codec.cpp
+++ b/src/remote/codec.cpp
@@ -950,9 +950,17 @@ void AbstractCodec::setByteOrder(int byteOrder)
 bool AbstractCodec::directSerialize(ByteBuffer* /*existingBuffer*/, const char* toSerialize,
                                     std::size_t elementCount, std::size_t elementSize)
 {
-    // TODO overflow check of "size_t count", overflow int32 field of payloadSize header field
     // TODO max message size in connection validation
+
+    // Reject sizes that would overflow the size_t product or the signed
+    // int32 payloadSize header field, which would desync the wire stream.
+    if (elementSize != 0 &&
+        elementCount > std::numeric_limits<std::size_t>::max() / elementSize)
+        throw std::overflow_error("directSerialize: element count * size overflows size_t");
     std::size_t count = elementCount * elementSize;
+
+    if (count > static_cast<std::size_t>(std::numeric_limits<int32>::max()))
+        throw std::overflow_error("directSerialize: payload size exceeds int32");
 
     // TODO find smart limit
     // check if direct mode actually pays off

--- a/src/remote/codec.cpp
+++ b/src/remote/codec.cpp
@@ -1678,7 +1678,10 @@ void BlockingServerTCPTransportCodec::authNZInitialize(const std::string& securi
     info->authority = securityPluginName;
 
     if (!plugin->isValidFor(*info))
+    {
         verified(pvData::Status::error("invalid security plug-in name"));
+        return;
+    }
 
     if (IS_LOGGABLE(logLevelDebug))
     {

--- a/src/remote/security.cpp
+++ b/src/remote/security.cpp
@@ -319,11 +319,12 @@ void AuthNZHandler::handleResponse(osiSockAddr* responseFrom,
 
     pvd::PVStructure::shared_pointer data;
     {
-        pvd::PVField::shared_pointer raw(SerializationHelper::deserializeFull(payloadBuffer, transport.get()));
-        if(raw->getField()->getType()==pvd::structure) {
+        pvd::PVField::shared_pointer raw(
+                SerializationHelper::deserializeFull(payloadBuffer, transport.get()));
+        if (raw && raw->getField()->getType()==pvd::structure) {
             data = std::tr1::static_pointer_cast<pvd::PVStructure>(raw);
         } else {
-            // was originally possible, but never used
+            return; // ignore
         }
     }
 

--- a/src/server/baseChannelRequester.cpp
+++ b/src/server/baseChannelRequester.cpp
@@ -66,7 +66,8 @@ int32 BaseChannelRequester::getPendingRequest()
 string BaseChannelRequester::getRequesterName()
 {
     std::stringstream name;
-    name << typeid(*_transport).name() << "/" << _ioid;
+    Transport& transport = *_transport;
+    name << typeid(transport).name() << "/" << _ioid;
     return name.str();
 }
 

--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -1170,19 +1170,17 @@ void ServerChannelGetRequesterImpl::destroy()
     // destroyed prematurely
     shared_pointer self(shared_from_this());
 
-    // hold a reference to channelGet so that _channelGet.reset()
-    // does not call ~ChannelGet (external code) while we are holding a lock
-    ChannelGet::shared_pointer channelGet = _channelGet;
+    // Take ownership of the ChannelGet under our lock, but
+    // its destroy() and destructor must run outside the lock.
+    ChannelGet::shared_pointer channelGet;
     {
         Lock guard(_mutex);
         _channel->unregisterRequest(_ioid);
-
-        if (_channelGet)
-        {
-            _channelGet->destroy();
-            _channelGet.reset();
-        }
+        channelGet.swap(_channelGet);
     }
+
+    if (channelGet)
+        channelGet->destroy();
 }
 
 ChannelGet::shared_pointer ServerChannelGetRequesterImpl::getChannelGet()
@@ -1406,19 +1404,17 @@ void ServerChannelPutRequesterImpl::destroy()
     // destroyed prematurely
     shared_pointer self(shared_from_this());
 
-    // hold a reference to channelGet so that _channelPut.reset()
-    // does not call ~ChannelPut (external code) while we are holding a lock
-    ChannelPut::shared_pointer channelPut = _channelPut;
+    // Take ownership of the ChannelPut under our lock, but
+    // its destroy() and destructor must run outside the lock.
+    ChannelPut::shared_pointer channelPut;
     {
         Lock guard(_mutex);
         _channel->unregisterRequest(_ioid);
-
-        if (_channelPut)
-        {
-            _channelPut->destroy();
-            _channelPut.reset();
-        }
+        channelPut.swap(_channelPut);
     }
+
+    if (channelPut)
+        channelPut->destroy();
 }
 
 ChannelPut::shared_pointer ServerChannelPutRequesterImpl::getChannelPut()
@@ -1675,19 +1671,17 @@ void ServerChannelPutGetRequesterImpl::destroy()
     // destroyed prematurely
     shared_pointer self(shared_from_this());
 
-    // hold a reference to channelPutGet so that _channelPutGet.reset()
-    // does not call ~ChannelPutGet (external code) while we are holding a lock
-    ChannelPutGet::shared_pointer channelPutGet = _channelPutGet;
+    // Take ownership of the ChannelPutGet under our lock, but
+    // its destroy() and destructor must run outside the lock.
+    ChannelPutGet::shared_pointer channelPutGet;
     {
         Lock guard(_mutex);
         _channel->unregisterRequest(_ioid);
-
-        if (_channelPutGet)
-        {
-            _channelPutGet->destroy();
-            _channelPutGet.reset();
-        }
+        channelPutGet.swap(_channelPutGet);
     }
+
+    if (channelPutGet)
+        channelPutGet->destroy();
 }
 
 ChannelPutGet::shared_pointer ServerChannelPutGetRequesterImpl::getChannelPutGet()
@@ -2317,19 +2311,17 @@ void ServerChannelArrayRequesterImpl::destroy()
     // destroyed prematurely
     shared_pointer self(shared_from_this());
 
-    // hold a reference to channelArray so that _channelArray.reset()
-    // does not call ~ChannelArray (external code) while we are holding a lock
-    ChannelArray::shared_pointer channelArray = _channelArray;
+    // Take ownership of the ChannelArray under our lock, but
+    // its destroy() and destructor must run outside the lock.
+    ChannelArray::shared_pointer channelArray;
     {
         Lock guard(_mutex);
         _channel->unregisterRequest(_ioid);
-
-        if (_channelArray)
-        {
-            _channelArray->destroy();
-            _channelArray.reset();
-        }
+        channelArray.swap(_channelArray);
     }
+
+    if (channelArray)
+        channelArray->destroy();
 }
 
 ChannelArray::shared_pointer ServerChannelArrayRequesterImpl::getChannelArray()
@@ -2848,17 +2840,17 @@ void ServerChannelRPCRequesterImpl::destroy()
     // destroyed prematurely
     shared_pointer self(shared_from_this());
 
+    // Take ownership of the ChannelRPC under our lock, but
+    // its destroy() and destructor must run outside the lock.
+    ChannelRPC::shared_pointer channelRPC;
     {
         Lock guard(_mutex);
         _channel->unregisterRequest(_ioid);
-
-        if (_channelRPC.get())
-        {
-            _channelRPC->destroy();
-        }
+        channelRPC.swap(_channelRPC);
     }
-    // TODO
-    _channelRPC.reset();
+
+    if (channelRPC)
+        channelRPC->destroy();
 }
 
 ChannelRPC::shared_pointer ServerChannelRPCRequesterImpl::getChannelRPC()

--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -348,10 +348,18 @@ void ServerSearchHandler::handleResponse(osiSockAddr* responseFrom,
         {
             transport->ensureData(4);
             const int32 cid = payloadBuffer->getInt();
-            const string name = SerializeHelper::deserializeString(payloadBuffer, transport.get());
 
-            // Ignore over-length names
-            if (allowed && name.size() <= MAX_CHANNEL_NAME_LENGTH)
+#ifdef DESERIALIZE_STRING_HAS_LIMIT
+#  define COMMA_MAX_CHANNEL_NAME_LEN , MAX_CHANNEL_NAME_LENGTH
+#  define NAME_SIZE_OK 1
+#else
+#  define COMMA_MAX_CHANNEL_NAME_LEN
+#  define NAME_SIZE_OK (name.size() <= MAX_CHANNEL_NAME_LENGTH)
+#endif
+            const string name = SerializeHelper::deserializeString(payloadBuffer,
+                    transport.get() COMMA_MAX_CHANNEL_NAME_LEN);
+
+            if (allowed && NAME_SIZE_OK)
             {
                 const std::vector<ChannelProvider::shared_pointer>& _providers = _context->getChannelProviders();
 
@@ -740,7 +748,8 @@ void ServerCreateChannelHandler::handleResponse(osiSockAddr* responseFrom,
     }
     const pvAccessID cid = payloadBuffer->getInt();
 
-    string channelName = SerializeHelper::deserializeString(payloadBuffer, transport.get());
+    string channelName = SerializeHelper::deserializeString(payloadBuffer,
+            transport.get() COMMA_MAX_CHANNEL_NAME_LEN);
     if (channelName.size() == 0)
     {
         LOG(logLevelDebug,"Zero length channel name, disconnecting client: %s", transport->getRemoteName().c_str());

--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -1423,19 +1423,19 @@ void ServerChannelPutRequesterImpl::destroy()
 
 ChannelPut::shared_pointer ServerChannelPutRequesterImpl::getChannelPut()
 {
-    //Lock guard(_mutex);
+    Lock guard(_mutex);
     return _channelPut;
 }
 
 BitSet::shared_pointer ServerChannelPutRequesterImpl::getPutBitSet()
 {
-    //Lock guard(_mutex);
+    Lock guard(_mutex);
     return _bitSet;
 }
 
 PVStructure::shared_pointer ServerChannelPutRequesterImpl::getPutPVStructure()
 {
-    //Lock guard(_mutex);
+    Lock guard(_mutex);
     return _pvStructure;
 }
 
@@ -1692,19 +1692,19 @@ void ServerChannelPutGetRequesterImpl::destroy()
 
 ChannelPutGet::shared_pointer ServerChannelPutGetRequesterImpl::getChannelPutGet()
 {
-    //Lock guard(_mutex);
+    Lock guard(_mutex);
     return _channelPutGet;
 }
 
 PVStructure::shared_pointer ServerChannelPutGetRequesterImpl::getPutGetPVStructure()
 {
-    //Lock guard(_mutex);
+    Lock guard(_mutex);
     return _pvPutStructure;
 }
 
 BitSet::shared_pointer ServerChannelPutGetRequesterImpl::getPutGetBitSet()
 {
-    //Lock guard(_mutex);
+    Lock guard(_mutex);
     return _pvPutBitSet;
 }
 
@@ -1746,14 +1746,14 @@ void ServerChannelPutGetRequesterImpl::send(ByteBuffer* buffer, TransportSendCon
         else if ((QOS_GET_PUT & request) != 0)
         {
             ScopedLock lock(channelPutGet);
-            //Lock guard(_mutex);
+            Lock guard(_mutex);
             _pvPutBitSet->serialize(buffer, control);
             _pvPutStructure->serialize(buffer, control, _pvPutBitSet.get());
         }
         else
         {
             ScopedLock lock(channelPutGet);
-            //Lock guard(_mutex);
+            Lock guard(_mutex);
             _pvGetBitSet->serialize(buffer, control);
             _pvGetStructure->serialize(buffer, control, _pvGetBitSet.get());
         }
@@ -2334,13 +2334,13 @@ void ServerChannelArrayRequesterImpl::destroy()
 
 ChannelArray::shared_pointer ServerChannelArrayRequesterImpl::getChannelArray()
 {
-    //Lock guard(_mutex);
+    Lock guard(_mutex);
     return _channelArray;
 }
 
 PVArray::shared_pointer ServerChannelArrayRequesterImpl::getPVArray()
 {
-    //Lock guard(_mutex);
+    Lock guard(_mutex);
     return _pvArray;
 }
 
@@ -2369,13 +2369,13 @@ void ServerChannelArrayRequesterImpl::send(ByteBuffer* buffer, TransportSendCont
     {
         if ((QOS_GET & request) != 0)
         {
-            //Lock guard(_mutex);
+            Lock guard(_mutex);
             ScopedLock lock(channelArray);
             _pvArray->serialize(buffer, control, 0, _pvArray->getLength());
         }
         else if ((QOS_PROCESS & request) != 0)
         {
-            //Lock guard(_mutex);
+            Lock guard(_mutex);
             SerializeHelper::writeSize(_length, buffer, control);
         }
         else if ((QOS_INIT & request) != 0)
@@ -2610,7 +2610,7 @@ void ServerChannelProcessRequesterImpl::destroy()
 
 ChannelProcess::shared_pointer ServerChannelProcessRequesterImpl::getChannelProcess()
 {
-    //Lock guard(_mutex);
+    Lock guard(_mutex);
     return _channelProcess;
 }
 
@@ -2863,7 +2863,7 @@ void ServerChannelRPCRequesterImpl::destroy()
 
 ChannelRPC::shared_pointer ServerChannelRPCRequesterImpl::getChannelRPC()
 {
-    //Lock guard(_mutex);
+    Lock guard(_mutex);
     return _channelRPC;
 }
 

--- a/src/server/responseHandlers.cpp
+++ b/src/server/responseHandlers.cpp
@@ -349,9 +349,9 @@ void ServerSearchHandler::handleResponse(osiSockAddr* responseFrom,
             transport->ensureData(4);
             const int32 cid = payloadBuffer->getInt();
             const string name = SerializeHelper::deserializeString(payloadBuffer, transport.get());
-            // no name check here...
 
-            if (allowed)
+            // Ignore over-length names
+            if (allowed && name.size() <= MAX_CHANNEL_NAME_LENGTH)
             {
                 const std::vector<ChannelProvider::shared_pointer>& _providers = _context->getChannelProviders();
 

--- a/src/server/serverChannelImpl.cpp
+++ b/src/server/serverChannelImpl.cpp
@@ -103,8 +103,9 @@ void ServerChannel::printInfo() const
 
 void ServerChannel::printInfo(FILE *fd) const
 {
+    Channel& channel = *_channel;
     fprintf(fd,"CLASS        : %s\n", typeid(*this).name());
-    fprintf(fd,"CHANNEL      : %s\n", typeid(*_channel).name());
+    fprintf(fd,"CHANNEL      : %s\n", typeid(channel).name());
 }
 
 void ServerChannel::installGetField(const GetFieldRequester::shared_pointer& gf)

--- a/testApp/remote/testCodec.cpp
+++ b/testApp/remote/testCodec.cpp
@@ -432,10 +432,11 @@ class CodecTest {
 public:
 
     int runAllTest() {
-        testPlan(5883);
+        testPlan(5889);
         testHeaderProcess();
         testInvalidHeaderMagic();
         testInvalidHeaderSegmentedInNormal();
+        testNegativePayloadSize();
         testInvalidHeaderPayloadNotRead();
         testHeaderSplitRead();
         testNonEmptyPayload();
@@ -600,6 +601,57 @@ private:
         testOk(codec._receivedAppMessages.size() == 0,
                "%s: codec._receivedAppMessages.size() == 0",
                CURRENT_FUNCTION);
+    }
+
+
+    void testNegativePayloadSize()
+    {
+
+        testDiag("BEGIN TEST %s:", CURRENT_FUNCTION);
+
+        // A negative payload size sign-extends to a huge size_t and corrupts
+        // the buffer limit/position math; application messages must reject it.
+        int32_t negativeValues[] =
+        {(int32_t)0xFFFFFFFF, (int32_t)0x80000000};
+
+        std::size_t size = sizeof(negativeValues)/sizeof(int32_t);
+
+        for (std::size_t i = 0; i < size; i++)
+        {
+            TestCodec codec(DEFAULT_BUFFER_SIZE,DEFAULT_BUFFER_SIZE);
+            codec._readBuffer->put(PVA_MAGIC);
+            codec._readBuffer->put(PVA_CLIENT_PROTOCOL_REVISION);
+            codec._readBuffer->put((int8_t)0x00);   // application, first segment
+            codec._readBuffer->put((int8_t)0x23);
+            codec._readBuffer->putInt(negativeValues[i]);
+            codec._readBuffer->flip();
+
+            codec.processRead();
+
+            testOk(codec._invalidDataStreamCount == 1,
+                   "%s: negative app payload rejected", CURRENT_FUNCTION);
+            testOk(codec._receivedAppMessages.size() == 0,
+                   "%s: no app message accepted", CURRENT_FUNCTION);
+        }
+
+        // For control messages the field is opaque data, not a length;
+        // a negative value must still be accepted.
+        {
+            TestCodec codec(DEFAULT_BUFFER_SIZE,DEFAULT_BUFFER_SIZE);
+            codec._readBuffer->put(PVA_MAGIC);
+            codec._readBuffer->put(PVA_CLIENT_PROTOCOL_REVISION);
+            codec._readBuffer->put((int8_t)0x01);   // control message
+            codec._readBuffer->put((int8_t)0x23);
+            codec._readBuffer->putInt((int32_t)0xDDCCBBAA);
+            codec._readBuffer->flip();
+
+            codec.processRead();
+
+            testOk(codec._invalidDataStreamCount == 0,
+                   "%s: negative control payload accepted", CURRENT_FUNCTION);
+            testOk(codec._receivedControlMessages.size() == 1,
+                   "%s: control message accepted", CURRENT_FUNCTION);
+        }
     }
 
 


### PR DESCRIPTION
Moved from the private area.

By commit:

1. Reject negative payload sizes in messages over UDP and TCP, with tests.
It looks like this module can't handle TCP or UDP messages over 2^31 Bytes, although the TCP code apparently understands joining segmented messages.

2. Ignore over-long channel names in search messages.
This commit skips over names longer than would be accepted by the channel create code. A better response might be to immediately discard the search message, research needed on how to implement that.

3. Uncomment Lock guards that were improperly disabled long ago.
See [the gist here (2nd document)](https://gist.github.com/anjohnson/9cd360c3d1dc010aaddec46439a73838#file-lock-guard-analysis-md) for Claude's assessment of the lock guard history.

4. Prevent deadlocks in `destroy()` methods.
See [the gist here (1st document)](https://gist.github.com/anjohnson/9cd360c3d1dc010aaddec46439a73838#file-deadlock-check-serverchannelputgetrequesterimpl-send-md) for Claude's explanation of fixes like one by @mdavidsaver in 2018.

5. Limit strings accepted as channel names to `MAX_CHANNEL_NAME_LENGTH`, ignoring anything larger. This requires a change implemented in my pvData add-protection branch, epics-base/pvDataCPP#107